### PR TITLE
PR: Add documentation for PyHELP installation on the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pip wheels and conda packages are both available for Python 3.6 on the Windows 6
 
 The easiest method to install the released version of PyHELP on Windows is with [Conda](https://conda.io/docs/index.html). To do so, you will need first to download and install the [Anaconda distribution](https://www.anaconda.com/distribution/) on your computer. Anaconda comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment.
 
-PyHELP can then be installed, along with all its dependencies, by executing the following `conda` command in a terminal:
+Than, PyHELP can be installed, along with all its dependencies, by executing the following `conda` command in a terminal:
 
 `conda install -c cgq-qgc pyhelp scipy geopandas xlrd netcdf4 h5py pytables matplotlib`
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Please consult the [documentation](http://pyhelp.readthedocs.io) for more detail
 # Install
 
 [![pypi version](https://img.shields.io/pypi/v/pyhelp.svg)](https://pypi.org/project/pyhelp/)
+[![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/version.svg)](https://anaconda.org/cgq-qgc/pyhelp)
 [![conda version](https://img.shields.io/conda/vn/cgq-qgc/pyhelp.svg)](https://anaconda.org/cgq-qgc/pyhelp)
 
 If you are new to Python or the Scientific Python ecosystem, we strongly recommend you to install and use [Anaconda](https://www.anaconda.com/download/) (miniconda is fine as well). It comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment. We also support [pip](https://pypi.org/project/pip/), but please be aware that pip installations are for advanced users. PyHELP depends on several low-level libraries for geospatial analysis, and this may cause dependency conflicts if you are not careful.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ PyHELP is a [Python](https://www.python.org/) library for the assessment of grou
 
 Please consult the [documentation](http://pyhelp.readthedocs.io) for more details or contact us at [jean-sebastien.gosselin@ete.inrs.ca](mailto:jean-sebastien.gosselin@ete.inrs.ca).
 
-## Install from built distributions
+## Install
 
-Pip wheels and conda packages are both available for Python 3.6 on the Windows 64bits plateform. If you need to use PyHELP with Python 3.7 or are working on Linux or MacOS, you will have to build and install PyHELP from source.
+Pip wheels and conda packages are both available for Python 3.6 on the Windows 64bits plateform. If you need to use PyHELP with Python 3.7 or are working on Linux or MacOS, you will have to build and install PyHELP from source. Please contact us if you need help with that.
 
 [![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/installer/conda.svg)](https://anaconda.org/cgq-qgc/pyhelp)
 
@@ -27,11 +27,11 @@ PyHELP can then be installed, along with all its dependencies, by executing the 
 
 It is also possible to install PyHELP with [pip](https://pypi.org/project/pip/), but be aware that pip installations are for advanced users. PyHELP depends on several low-level libraries for geospatial analysis, and this may cause dependency conflicts if you are not careful.
 
-First, you will need to download and install [Python 3.6](https://www.python.org/downloads/release/python-367/) on your computer. Then you will need to download and install with `pip`, in that specific order, `numpy`, `matplotlib`, `scipy`, `pandas`, `shapely`, `fiona`, `pyproj`, `geopandas`, `h5py`, `pytables`, `xlrd`, `netcdf4`from Christopher Gohlke's [Unofficial Windows Binaries for Python Extension Packages](https://www.lfd.uci.edu/~gohlke/pythonlibs/). Be carefull to install the packages that were built for Python 3.6 and Windows 64bits.
+First, you will need to download and install [Python 3.6](https://www.python.org/downloads/release/python-367/) on your computer. Then, the easiest way to install PyHELP's depencies is to download Wheels from Christopher Gohlke's [Unofficial Windows Binaries for Python Extension Packages](https://www.lfd.uci.edu/~gohlke/pythonlibs/) and [install them with pip](https://pip.pypa.io/en/stable/user_guide/#installing-from-wheels) in that specific order:  `numpy`, `matplotlib`, `scipy`, `pandas`, `shapely`, `fiona`, `pyproj`, `geopandas`, `h5py`, `pytables`, `xlrd`, `netcdf4`. Be carefull to install the packages that were built for Python 3.6 and Windows 64bits.
 
 Finally, you can install PyHELP with `pip` by executing the following command in a terminal:
 
-`python -m pip install `
+`python -m pip install pyhelp`
 
 
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,14 @@ PyHELP is a [Python](https://www.python.org/) library for the assessment of grou
 Please consult the [documentation](http://pyhelp.readthedocs.io) for more details or contact us at [jean-sebastien.gosselin@ete.inrs.ca](mailto:jean-sebastien.gosselin@ete.inrs.ca).
 
 # Install
-
 [![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/installer/conda.svg)](https://anaconda.org/cgq-qgc/pyhelp)
 [![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/installer/pypi.svg)](https://pypi.org/project/pyhelp/)
 
-If you are new to Python or the Scientific Python ecosystem, we strongly recommend you to install and use [Anaconda](https://www.anaconda.com/download/) (miniconda is fine as well). It comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment. We also support [pip](https://pypi.org/project/pip/), but please be aware that pip installations are for advanced users. PyHELP depends on several low-level libraries for geospatial analysis, and this may cause dependency conflicts if you are not careful.
+If you are new to Python or the Scientific Python ecosystem, we strongly recommend you to to install the released version of PyHELP with [Conda](https://conda.io/docs/index.html). To do so, you will need first to download and install the [Anaconda distribution](https://www.anaconda.com/distribution/) on your computer. Anaconda comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment. Then, the easiest way to install PyHELP and all its depencies is by executing the following `conda` command in a terminal:
+
+`conda install -c cgq-qgc pyhelp scipy geopandas xlrd netcdf4 h5py pytables matplotlib`
+
+We also support [pip](https://pypi.org/project/pip/), but be aware that pip installations are for advanced users. PyHELP depends on several low-level libraries for geospatial analysis, and this may cause dependency conflicts if you are not careful.
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![PyHELP](./images/pyhelp_banner.png)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![license](https://img.shields.io/pypi/l/pyhelp.svg)](./LICENSE)
 [![Latest release](https://img.shields.io/github/release/cgq-qgc/pyhelp.svg)](https://github.com/cgq-qgc/pyhelp/releases)
 [![Documentation Status](https://readthedocs.org/projects/pyhelp/badge/?version=latest)](http://pyhelp.readthedocs.io)
 [![Build status](https://ci.appveyor.com/api/projects/status/ns6s8x0hkd31ffb3/branch/master?svg=true)](https://ci.appveyor.com/project/jnsebgosselin/pyhelp-rd625/branch/master)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,5 @@ Please consult the [documentation](http://pyhelp.readthedocs.io) for more detail
 
 [![pypi version](https://img.shields.io/pypi/v/pyhelp.svg)](https://pypi.org/project/pyhelp/)
 [![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/version.svg)](https://anaconda.org/cgq-qgc/pyhelp)
-[![conda version](https://img.shields.io/conda/vn/cgq-qgc/pyhelp.svg)](https://anaconda.org/cgq-qgc/pyhelp)
 
 If you are new to Python or the Scientific Python ecosystem, we strongly recommend you to install and use [Anaconda](https://www.anaconda.com/download/) (miniconda is fine as well). It comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment. We also support [pip](https://pypi.org/project/pip/), but please be aware that pip installations are for advanced users. PyHELP depends on several low-level libraries for geospatial analysis, and this may cause dependency conflicts if you are not careful.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,29 @@ Please consult the [documentation](http://pyhelp.readthedocs.io) for more detail
 
 ## Install from built distributions
 
+Pip wheels and conda packages are both available for Python 3.6 on the Windows 64bits plateform. If you need to use PyHELP with Python 3.7 or are working on Linux or MacOS, you will have to build and install PyHELP from source.
+
 [![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/installer/conda.svg)](https://anaconda.org/cgq-qgc/pyhelp)
-[![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/installer/pypi.svg)](https://pypi.org/project/pyhelp/)
 
-Pip wheels and conda packages are both available for the Windows 64bits plateform. If you are on Linux or MacOS, you will have to build and install PyHELP from source.
+The easiest method to install the released version of PyHELP on Windows is with [Conda](https://conda.io/docs/index.html). To do so, you will need first to download and install the [Anaconda distribution](https://www.anaconda.com/distribution/) on your computer. Anaconda comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment.
 
-The easiest method to install the released version of PyHELP on Windows is with [Conda](https://conda.io/docs/index.html). To do so, you will need first to download and install the [Anaconda distribution](https://www.anaconda.com/distribution/) on your computer. Anaconda comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment. Once this is done, PyHELP can be installed, along with all its dependencies, simply by executing the following `conda` command in a terminal:
+PyHELP can then be installed, along with all its dependencies, by executing the following `conda` command in a terminal:
 
 `conda install -c cgq-qgc pyhelp scipy geopandas xlrd netcdf4 h5py pytables matplotlib`
 
+[![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/installer/pypi.svg)](https://pypi.org/project/pyhelp/)
+
 It is also possible to install PyHELP with [pip](https://pypi.org/project/pip/), but be aware that pip installations are for advanced users. PyHELP depends on several low-level libraries for geospatial analysis, and this may cause dependency conflicts if you are not careful.
+
+First, you will need to download and install [Python 3.6](https://www.python.org/downloads/release/python-367/) on your computer. Then you will need to download and install with `pip`, in that specific order, `numpy`, `matplotlib`, `scipy`, `pandas`, `shapely`, `fiona`, `pyproj`, `geopandas`, `h5py`, `pytables`, `xlrd`, `netcdf4`from Christopher Gohlke's [Unofficial Windows Binaries for Python Extension Packages](https://www.lfd.uci.edu/~gohlke/pythonlibs/). Be carefull to install the packages that were built for Python 3.6 on Windows 64bits.
+
+Finally, you can install PyHELP by executing the following Python command in a terminal:
+
+`python -m pip install `
+
+
+
+
+
+
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pip wheels and conda packages are both available for Python 3.6 on the Windows 6
 
 The easiest method to install the released version of PyHELP on Windows is with [Conda](https://conda.io/docs/index.html). To do so, you will need first to download and install the [Anaconda distribution](https://www.anaconda.com/distribution/) on your computer. Anaconda comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment.
 
-Than, PyHELP can be installed, along with all its dependencies, by executing the following `conda` command in a terminal:
+Then, PyHELP can be installed, along with all its dependencies, by executing the following `conda` command in a terminal:
 
 `conda install -c cgq-qgc pyhelp scipy geopandas xlrd netcdf4 h5py pytables matplotlib`
 

--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@
 PyHELP is a [Python](https://www.python.org/) library for the assessment of groundwater recharge at the regional scale with the [Hydrologic Evaluation of Landfill Performance](https://www.epa.gov/land-research/hydrologic-evaluation-landfill-performance-help-model) (HELP) model.
 
 Please consult the [documentation](http://pyhelp.readthedocs.io) for more details or contact us at [jean-sebastien.gosselin@ete.inrs.ca](mailto:jean-sebastien.gosselin@ete.inrs.ca).
+
+# Install
+
+[![pypi version](https://img.shields.io/pypi/v/pyhelp.svg)](https://pypi.org/project/pyhelp/)
+
+If you are new to Python or the Scientific Python ecosystem, we strongly recommend you to install and use [Anaconda](https://www.anaconda.com/download/) (miniconda is fine as well). It comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment. We also support [pip](https://pypi.org/project/pip/), but please be aware that pip installations are for advanced users. PyHELP depends on several low-level libraries for geospatial analysis, and this may cause dependency conflicts if you are not careful.

--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@ PyHELP is a [Python](https://www.python.org/) library for the assessment of grou
 
 Please consult the [documentation](http://pyhelp.readthedocs.io) for more details or contact us at [jean-sebastien.gosselin@ete.inrs.ca](mailto:jean-sebastien.gosselin@ete.inrs.ca).
 
-# Install
+## Install from built distributions
+
 [![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/installer/conda.svg)](https://anaconda.org/cgq-qgc/pyhelp)
 [![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/installer/pypi.svg)](https://pypi.org/project/pyhelp/)
 
-If you are new to Python or the Scientific Python ecosystem, we strongly recommend you to to install the released version of PyHELP with [Conda](https://conda.io/docs/index.html). To do so, you will need first to download and install the [Anaconda distribution](https://www.anaconda.com/distribution/) on your computer. Anaconda comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment. Then, the easiest way to install PyHELP and all its depencies is by executing the following `conda` command in a terminal:
+Pip wheels and conda packages are both available for the Windows 64bits plateform. If you are on Linux or MacOS, you will have to build and install PyHELP from source.
+
+The easiest method to install the released version of PyHELP on Windows is with [Conda](https://conda.io/docs/index.html). To do so, you will need first to download and install the [Anaconda distribution](https://www.anaconda.com/distribution/) on your computer. Anaconda comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment. Once this is done, PyHELP can be installed, along with all its dependencies, simply by executing the following `conda` command in a terminal:
 
 `conda install -c cgq-qgc pyhelp scipy geopandas xlrd netcdf4 h5py pytables matplotlib`
 
-We also support [pip](https://pypi.org/project/pip/), but be aware that pip installations are for advanced users. PyHELP depends on several low-level libraries for geospatial analysis, and this may cause dependency conflicts if you are not careful.
-
-
+It is also possible to install PyHELP with [pip](https://pypi.org/project/pip/), but be aware that pip installations are for advanced users. PyHELP depends on several low-level libraries for geospatial analysis, and this may cause dependency conflicts if you are not careful.
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Please consult the [documentation](http://pyhelp.readthedocs.io) for more detail
 
 ## Install
 
-Pip wheels and conda packages are both available for Python 3.6 on the Windows 64bits plateform. If you need to use PyHELP with Python 3.7 or are working on Linux or MacOS, you will have to build and install PyHELP from source. Please contact us if you need help with that.
+Pip Wheels and Conda packages are both available for Python 3.6 on the Windows 64bits plateform. If you need to use PyHELP with Python 3.7 or are working on Linux or MacOS, you will have to build and install PyHELP from source. Please contact us if you need help with that.
 
 [![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/installer/conda.svg)](https://anaconda.org/cgq-qgc/pyhelp)
 
-The easiest method to install the released version of PyHELP on Windows is with [Conda](https://conda.io/docs/index.html). To do so, you will need first to download and install the [Anaconda distribution](https://www.anaconda.com/distribution/) on your computer. Anaconda comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment.
+The easiest method to install a released version of PyHELP on Windows is with [Conda](https://conda.io/docs/index.html). To do so, you will need first to download and install the [Anaconda distribution](https://www.anaconda.com/distribution/) on your computer. Anaconda comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment.
 
-Then, PyHELP can be installed, along with all its dependencies, by executing the following `conda` command in a terminal:
+Then, PyHELP can be installed, along with all its dependencies, by executing the following command in a terminal:
 
 `conda install -c cgq-qgc pyhelp scipy geopandas xlrd netcdf4 h5py pytables matplotlib`
 
@@ -27,7 +27,7 @@ Then, PyHELP can be installed, along with all its dependencies, by executing the
 
 It is also possible to install PyHELP with [pip](https://pypi.org/project/pip/), but be aware that pip installations are for advanced users. PyHELP depends on several low-level libraries for geospatial analysis, and this may cause dependency conflicts if you are not careful.
 
-First, you will need to download and install [Python 3.6](https://www.python.org/downloads/release/python-367/) on your computer. Then, the easiest way to install PyHELP's depencies is to download Wheels from Christopher Gohlke's [Unofficial Windows Binaries for Python Extension Packages](https://www.lfd.uci.edu/~gohlke/pythonlibs/) and [install them with pip](https://pip.pypa.io/en/stable/user_guide/#installing-from-wheels) in that specific order:  `numpy`, `matplotlib`, `scipy`, `pandas`, `shapely`, `fiona`, `pyproj`, `geopandas`, `h5py`, `pytables`, `xlrd`, `netcdf4`. Be carefull to install the packages that were built for Python 3.6 and Windows 64bits.
+First, you will need to download and install [Python 3.6](https://www.python.org/downloads/release/python-367/) on your computer. Then, the easiest way to install PyHELP's depencies on Windows is to download Wheels from Christopher Gohlke's [Unofficial Windows Binaries for Python Extension Packages](https://www.lfd.uci.edu/~gohlke/pythonlibs/) and [install them with pip](https://pip.pypa.io/en/stable/user_guide/#installing-from-wheels) in that specific order:  `numpy`, `matplotlib`, `scipy`, `pandas`, `shapely`, `fiona`, `pyproj`, `geopandas`, `h5py`, `pytables`, `xlrd`, `netcdf4`. Be carefull to install the packages that were built for Python 3.6 and Windows 64bits.
 
 Finally, you can install PyHELP with `pip` by executing the following command in a terminal:
 

--- a/README.md
+++ b/README.md
@@ -14,5 +14,6 @@ Please consult the [documentation](http://pyhelp.readthedocs.io) for more detail
 # Install
 
 [![pypi version](https://img.shields.io/pypi/v/pyhelp.svg)](https://pypi.org/project/pyhelp/)
+[![conda version](https://img.shields.io/conda/vn/cgq-qgc/pyhelp.svg)](https://anaconda.org/cgq-qgc/pyhelp)
 
 If you are new to Python or the Scientific Python ecosystem, we strongly recommend you to install and use [Anaconda](https://www.anaconda.com/download/) (miniconda is fine as well). It comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment. We also support [pip](https://pypi.org/project/pip/), but please be aware that pip installations are for advanced users. PyHELP depends on several low-level libraries for geospatial analysis, and this may cause dependency conflicts if you are not careful.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please consult the [documentation](http://pyhelp.readthedocs.io) for more detail
 
 # Install
 
-[![pypi version](https://img.shields.io/pypi/v/pyhelp.svg)](https://pypi.org/project/pyhelp/)
-[![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/version.svg)](https://anaconda.org/cgq-qgc/pyhelp)
+[![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/installer/conda.svg)](https://anaconda.org/cgq-qgc/pyhelp)
+[![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/installer/pypi.svg)](https://pypi.org/project/pyhelp/)
 
 If you are new to Python or the Scientific Python ecosystem, we strongly recommend you to install and use [Anaconda](https://www.anaconda.com/download/) (miniconda is fine as well). It comes with the most important Python scientific libraries (i.e. Numpy, Pandas, Matplotlib, IPython, etc), including all PyHELP dependencies, in a single, easy to use environment. We also support [pip](https://pypi.org/project/pip/), but please be aware that pip installations are for advanced users. PyHELP depends on several low-level libraries for geospatial analysis, and this may cause dependency conflicts if you are not careful.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ PyHELP can then be installed, along with all its dependencies, by executing the 
 
 It is also possible to install PyHELP with [pip](https://pypi.org/project/pip/), but be aware that pip installations are for advanced users. PyHELP depends on several low-level libraries for geospatial analysis, and this may cause dependency conflicts if you are not careful.
 
-First, you will need to download and install [Python 3.6](https://www.python.org/downloads/release/python-367/) on your computer. Then you will need to download and install with `pip`, in that specific order, `numpy`, `matplotlib`, `scipy`, `pandas`, `shapely`, `fiona`, `pyproj`, `geopandas`, `h5py`, `pytables`, `xlrd`, `netcdf4`from Christopher Gohlke's [Unofficial Windows Binaries for Python Extension Packages](https://www.lfd.uci.edu/~gohlke/pythonlibs/). Be carefull to install the packages that were built for Python 3.6 on Windows 64bits.
+First, you will need to download and install [Python 3.6](https://www.python.org/downloads/release/python-367/) on your computer. Then you will need to download and install with `pip`, in that specific order, `numpy`, `matplotlib`, `scipy`, `pandas`, `shapely`, `fiona`, `pyproj`, `geopandas`, `h5py`, `pytables`, `xlrd`, `netcdf4`from Christopher Gohlke's [Unofficial Windows Binaries for Python Extension Packages](https://www.lfd.uci.edu/~gohlke/pythonlibs/). Be carefull to install the packages that were built for Python 3.6 and Windows 64bits.
 
-Finally, you can install PyHELP by executing the following Python command in a terminal:
+Finally, you can install PyHELP with `pip` by executing the following command in a terminal:
 
 `python -m pip install `
 


### PR DESCRIPTION
Partial fix for Issue #35

This PR add install instruction for PyHELP with `conda` and `pip` in the README.

These instructions will be added to the documentation on RTD in another PR.
