### PR TITLE
PR: Add PyHELP dependencies to Conda package meta.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The easiest method to install a released version of PyHELP on Windows is with [C
 
 Then, PyHELP can be installed, along with all its dependencies, by executing the following command in a terminal:
 
+`conda install -c cgq-qgc pyhelp`
 
 [![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/installer/pypi.svg)](https://pypi.org/project/pyhelp/)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ The easiest method to install a released version of PyHELP on Windows is with [C
 
 Then, PyHELP can be installed, along with all its dependencies, by executing the following command in a terminal:
 
-`conda install -c cgq-qgc pyhelp scipy geopandas xlrd netcdf4 h5py pytables matplotlib`
 
 [![Anaconda-Server Badge](https://anaconda.org/cgq-qgc/pyhelp/badges/installer/pypi.svg)](https://pypi.org/project/pyhelp/)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,7 @@ test_script:
 after_test:
   - IF ["%APPVEYOR_PULL_REQUEST_NUMBER%"]==[""] (%PYTHON%/python.exe setup.py sdist bdist_wheel)
   - IF ["%APPVEYOR_REPO_TAG%"] == ["true"] (python -m twine upload dist/*)
-  - IF [""]==[""] (conda-build recipe --no-test --output-folder dist)
+  - IF ["%APPVEYOR_PULL_REQUEST_NUMBER%"]==[""] (conda-build recipe --no-test --output-folder dist)
 
 artifacts:
   - path: 'dist/*.whl'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,7 @@ test_script:
 after_test:
   - IF ["%APPVEYOR_PULL_REQUEST_NUMBER%"]==[""] (%PYTHON%/python.exe setup.py sdist bdist_wheel)
   - IF ["%APPVEYOR_REPO_TAG%"] == ["true"] (python -m twine upload dist/*)
-  - IF ["%APPVEYOR_PULL_REQUEST_NUMBER%"]==[""] (conda-build recipe --no-test --output-folder dist)
+  - IF [""]==[""] (conda-build recipe --no-test --output-folder dist)
 
 artifacts:
   - path: 'dist/*.whl'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pytables
     
 about:
-  home: https://github.com/jnsebgosselin/pyhelp
+  home: https://github.com/cgq-qgc/pyhelp
   license: MIT
   license_file: LICENSE
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ about:
   home: https://github.com/cgq-qgc/pyhelp
   license: MIT
   license_file: LICENSE
+  doc_url: https://pyhelp.readthedocs.io/
 extra:
   recipe-maintainers:
     - jnsebgosselin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ about:
   license: MIT
   license_file: LICENSE
   doc_url: https://pyhelp.readthedocs.io/
+  summary: A Python library for assessing groundwater recharge at the regional scale with the HELP model
 extra:
   recipe-maintainers:
     - jnsebgosselin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,8 +15,15 @@ requirements:
     - libpython
   run:
     - python ==3.6
-    - numpy 1.15.*
-
+    - numpy
+    - matplotlib
+    - scipy
+    - geopandas
+    - xlrd
+    - netcdf4
+    - h5py
+    - pytables
+    
 about:
   home: https://github.com/jnsebgosselin/pyhelp
   license: MIT


### PR DESCRIPTION
This will allow to simplify greatly the installation process. After these changes, it will be possible to install PyHELP by executing:

`conda install -c cgq-qgc pyhelp`

instead of :

`conda install -c cgq-qgc pyhelp scipy geopandas xlrd netcdf4 h5py pytables matplotlib`

**Important**
We need to wait before merging this until we are ready to release a new version, so that the instruction to install PyHELP remains valid until then on the README page.