### PR TITLE
PR: Fix ReadTheDocs building

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,6 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
 html_theme = 'classic'
 
 # Theme options are theme-specific and customize the look and feel of a theme


### PR DESCRIPTION
Add an empty `Requirements.txt` file in the `docs` folder so that ReadTheDocs can successfully build the docs without worrying about the runtime requirements for PyHELP.

https://docs.readthedocs.io/en/latest/guides/specifying-dependencies.html#specifying-a-requirements-file