### PR TITLE
PR: Remove "read_concatenated_d10d11_file" function from code

### DIFF
--- a/pyhelp/preprocessing.py
+++ b/pyhelp/preprocessing.py
@@ -191,6 +191,7 @@ def format_d10d11_inputs(grid, cellnames, sf_edepth=1, sf_ulai=1):
 
 
 def write_d10d11_singlecell(packed_data):
+    """Write the content of cell in a D10 and D11 file."""
     fname, cid, d10data = packed_data
     with open(fname, 'w') as csvfile:
         writer = csv.writer(csvfile, lineterminator='\n')

--- a/pyhelp/preprocessing.py
+++ b/pyhelp/preprocessing.py
@@ -12,7 +12,6 @@
 import csv
 import time
 import os.path as osp
-from collections import OrderedDict
 import multiprocessing as mp
 from multiprocessing import Pool
 
@@ -187,51 +186,6 @@ def format_d10d11_inputs(grid, cellnames, sf_edepth=1, sf_ulai=1):
           (i+1, N, (i+1)/N*100))
     tac = time.clock()
     print('Task completed in %0.2f sec' % (tac-tic))
-
-    return d10dat, d11dat
-
-
-def read_concatenated_d10d11_file(path_d10file, path_d11file):
-    """
-    Read the concatenated D10 and D11 files that contain the D10 and D11 inputs
-    for all the cells. Return a formatted dictionary where the data
-    relative to each cell is saved as a list at the key that correspond to the
-    unique id of the cell.
-    """
-
-    enc = 'iso-8859-1'
-
-    # ---- Read and Format D11 File
-
-    with open(path_d11file, 'r', encoding=enc) as csvfile:
-        d11reader = list(csv.reader(csvfile))
-
-    d11dat = OrderedDict()
-    cellnames = []
-    for i in range(0, len(d11reader), 3):
-        cell_name, zone_name = d11reader[i+1][0].split()
-        d11dat[cell_name] = [d11reader[i],
-                             d11reader[i+1],
-                             d11reader[i+2]]
-        cellnames.append(cell_name)
-
-    # ---- Read and Format D10 File
-
-    with open(path_d10file, 'r', encoding=enc) as csvfile:
-        d10reader = list(csv.reader(csvfile))
-
-    d10dat = OrderedDict()
-    i = 0
-    curcell = None
-    nextcell = cellnames[i]
-    for line in d10reader:
-        if nextcell in line[0]:
-            d10dat[nextcell] = [line]
-            curcell = nextcell
-            nextcell = 'None' if i >= len(cellnames)-1 else cellnames[i+1]
-            i += 1
-        else:
-            d10dat[curcell].append(line)
 
     return d10dat, d11dat
 


### PR DESCRIPTION
The function `read_concatenated_d10d11_file` was used to read the concatenated D10 and D11 files that were produced by the application developed to run HELP in batch mode. However, we do not use this application anymore and we produce the D10 and D11 files for each cells directly from the csv. Therefore, this function was not used anymore and could safely be removed from the code base.