### PR TITLE
PR: Pin numpy to 1.15.* series or else building the HELP3O extension fails.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ install:
   - conda config --set always_yes yes
   - conda update -q conda
   - conda config --set auto_update_conda no
-  - conda install scipy geopandas xlrd netcdf4 h5py pytables matplotlib pytest pytest-mock pytest-cov pip m2w64-toolchain conda-build
+  - conda install numpy==1.15.* scipy geopandas xlrd netcdf4 h5py pytables matplotlib pytest pytest-mock pytest-cov pip m2w64-toolchain conda-build
   - python -m pip install codecov
 
   # Check that we have still the expected version and architecture for Python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - libpython
   run:
     - python
-    - numpy
+    - numpy 1.15.*
     - matplotlib
     - scipy
     - geopandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy ==1.15.*
 scipy
 pandas
 xlrd


### PR DESCRIPTION
Here is the traceback I get when trying to build the `HELP3O` extension:
```
In file included from C:\Miniconda36-x64\include/Python.h:119:0,
                 from build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.h:7,
                 from build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:2:
C:\Miniconda36-x64\include/pylifecycle.h:63:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
 int _Py_CheckPython3();
 ^
In file included from C:\Miniconda36-x64\include/Python.h:119:0,
                 from build\src.win-amd64-3.6\pyhelp\HELP3Omodule.c:14:
C:\Miniconda36-x64\include/pylifecycle.h:63:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
 int _Py_CheckPython3();
 ^
In file included from C:\Miniconda36-x64\lib\site-packages\numpy\core\include/numpy/ndarraytypes.h:1824:0,
                 from C:\Miniconda36-x64\lib\site-packages\numpy\core\include/numpy/ndarrayobject.h:12,
                 from C:\Miniconda36-x64\lib\site-packages\numpy\core\include/numpy/arrayobject.h:4,
                 from build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp/fortranobject.h:13,
                 from build\src.win-amd64-3.6\pyhelp\HELP3Omodule.c:16:
C:\Miniconda36-x64\lib\site-packages\numpy\core\include/numpy/npy_1_7_deprecated_api.h:14:9: note: #pragma message: C:\Miniconda36-x64\lib\site-packages\numpy\core\include/numpy/npy_1_7_deprecated_api.h(14) : Warning Msg: Using deprecated NumPy API, disable it with #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #pragma message(_WARN___LOC__"Using deprecated NumPy API, disable it with " \
         ^
In file included from C:\Miniconda36-x64\lib\site-packages\numpy\core\include/numpy/ndarraytypes.h:1824:0,
                 from C:\Miniconda36-x64\lib\site-packages\numpy\core\include/numpy/ndarrayobject.h:12,
                 from C:\Miniconda36-x64\lib\site-packages\numpy\core\include/numpy/arrayobject.h:4,
                 from build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.h:13,
                 from build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:2:
C:\Miniconda36-x64\lib\site-packages\numpy\core\include/numpy/npy_1_7_deprecated_api.h:14:9: note: #pragma message: C:\Miniconda36-x64\lib\site-packages\numpy\core\include/numpy/npy_1_7_deprecated_api.h(14) : Warning Msg: Using deprecated NumPy API, disable it with #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #pragma message(_WARN___LOC__"Using deprecated NumPy API, disable it with " \
         ^
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c: In function 'format_def':
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:113:32: warning: unknown conversion type character 'l' in format [-Wformat=]
     n = PyOS_snprintf(p, size, "array(%" NPY_INTP_FMT, def.dims.d[0]);
                                ^
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:113:32: warning: too many arguments for format [-Wformat-extra-args]
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:121:36: warning: unknown conversion type character 'l' in format [-Wformat=]
         n = PyOS_snprintf(p, size, ",%" NPY_INTP_FMT, def.dims.d[i]);
                                    ^
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:121:36: warning: too many arguments for format [-Wformat-extra-args]
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c: In function 'fortran_doc':
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:235:21: warning: unknown conversion type character 'z' in format [-Wformat=]
     fprintf(stderr, "fortranobject.c: fortran_doc: len(p)=%zd>%zd=size:"
                     ^
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:235:21: warning: unknown conversion type character 'z' in format [-Wformat=]
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:235:21: warning: too many arguments for format [-Wformat-extra-args]
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c: In function 'array_from_pyobj':
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:687:43: warning: unknown conversion type character 'l' in format [-Wformat=]
                 sprintf(mess+strlen(mess),"%" NPY_INTP_FMT ",",dims[i]);
                                           ^
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:687:43: warning: too many arguments for format [-Wformat-extra-args]
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:735:25: warning: unknown conversion type character 'l' in format [-Wformat=]
                         " -- expected at least elsize=%d but got %" NPY_INTP_FMT,
                         ^
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:735:25: warning: too many arguments for format [-Wformat-extra-args]
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:777:25: warning: unknown conversion type character 'l' in format [-Wformat=]
                         " -- expected elsize=%d but got %" NPY_INTP_FMT,
                         ^
build\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp\fortranobject.c:777:25: warning: too many arguments for format [-Wformat-extra-args]
build\src.win-amd64-3.6\pyhelp\HELP3Omodule.c:208:12: warning: 'f2py_size' defined but not used [-Wunused-function]
 static int f2py_size(PyArrayObject* var, ...)
            ^
compiling Fortran sources
Fortran f77 compiler: C:\Miniconda36-x64\Library\mingw-w64\bin\gfortran.exe -Wall -g -ffixed-form -fno-second-underscore -O3 -funroll-loops
Fortran f90 compiler: C:\Miniconda36-x64\Library\mingw-w64\bin\gfortran.exe -Wall -g -fno-second-underscore -O3 -funroll-loops
Fortran fix compiler: C:\Miniconda36-x64\Library\mingw-w64\bin\gfortran.exe -Wall -g -ffixed-form -fno-second-underscore -Wall -g -fno-second-underscore -O3 -funroll-loops
creating build\temp.win-amd64-3.6\Release\pyhelp
compile options: '-IC:\Miniconda36-x64\lib\site-packages\numpy\core\include -Ibuild\src.win-amd64-3.6\build\src.win-amd64-3.6\pyhelp -IC:\Miniconda36-x64\lib\site-packages\numpy\core\include -IC:\Miniconda36-x64\include -IC:\Miniconda36-x64\include -c'
gfortran.exe:f77: pyhelp/HELP3O.FOR
gfortran.exe:f77: build\src.win-amd64-3.6\pyhelp\HELP3O-f2pywrappers.f
pyhelp/HELP3O.FOR:1392:18:
         CON (J) = 2.44 + (1485216.*RC (J)*((BUB(J)/103.34)**
                  1
Warning: Possible change of value in conversion from REAL(8) to REAL(4) at (1) [-Wconversion]
pyhelp/HELP3O.FOR:1437:13:
       IDFS = 35.4 - (0.154 * RADAVG)
             1
Warning: Possible change of value in conversion from REAL(4) to INTEGER(4) at (1) [-Wconversion]
pyhelp/HELP3O.FOR:2047:19:
         RCULS(J) = RC(K)*DSEG + RCULS(J)
                   1
Warning: Possible change of value in conversion from REAL(8) to REAL(4) at (1) [-Wconversion]
pyhelp/HELP3O.FOR:2064:19:
         RCULS(J) = RC(K)*DSEG + RCULS(J)
                   1
Warning: Possible change of value in conversion from REAL(8) to REAL(4) at (1) [-Wconversion]
pyhelp/HELP3O.FOR:2084:21:
           RCULS(J) = RC(LAYSEG(J, 1))*STHICK(J)
                     1
Warning: Possible change of value in conversion from REAL(8) to REAL(4) at (1) [-Wconversion]
pyhelp/HELP3O.FOR:2657:15:
         RTOP = RC (1)
               1
Warning: Possible change of value in conversion from REAL(8) to REAL(4) at (1) [-Wconversion]
pyhelp/HELP3O.FOR:2660:39:
           IF (RC (I) .LT. RTOP) RTOP = RC (I)

[...]
```

There is a lot more of these `-Wconversion` warnings.