### PR TITLE
PR: Fix PyHELP output saving and loading

### DIFF
--- a/pyhelp/managers.py
+++ b/pyhelp/managers.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-# =============================================================================
-# Copyright © PyHelp Project Contributors
+# -----------------------------------------------------------------------------
+# Copyright © PyHELP Project Contributors
 # https://github.com/cgq-qgc/pyhelp
 #
-# This file is part of PyHelp.
+# This file is part of PyHELP.
 # Licensed under the terms of the MIT License.
-# =============================================================================
+# -----------------------------------------------------------------------------
 
 # ---- Standard Library Imports
 import json

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -7,6 +7,7 @@
 # Licensed under the terms of the MIT License.
 # -----------------------------------------------------------------------------
 
+from __future__ import annotations
 
 # ---- Standard Library imports
 import os.path as osp
@@ -26,7 +27,7 @@ class HelpOutput(Mapping):
     with the :class:`~pyhelp.HelpManager` class.
     """
 
-    def __init__(self, path_or_dict):
+    def __init__(self, path_or_dict: str | dict):
         super(HelpOutput, self).__init__()
         if isinstance(path_or_dict, dict):
             self.data = path_or_dict['data']
@@ -46,7 +47,7 @@ class HelpOutput(Mapping):
     def __len__(self):
         return len(self.data['cid'])
 
-    def load_from_hdf5(self, path_to_hdf5):
+    def load_from_hdf5(self, path_to_hdf5: str):
         """Read data and grid from an HDF5 file at the specified location."""
         print(f"Loading data and grid from {path_to_hdf5}")
         hdf5 = h5py.File(path_to_hdf5, mode='r+')
@@ -76,7 +77,7 @@ class HelpOutput(Mapping):
         finally:
             hdf5.close()
 
-    def save_to_hdf5(self, path_to_hdf5):
+    def save_to_hdf5(self, path_to_hdf5: str):
         """Save the data and grid to an HDF5 file at the specified location."""
         print("Saving data to {}...".format(osp.basename(path_to_hdf5)))
         hdf5file = h5py.File(path_to_hdf5, mode='w')

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
-# Copyright © PyHelp Project Contributors
+# Copyright © PyHELP Project Contributors
 # https://github.com/cgq-qgc/pyhelp
 #
 # This file is part of PyHELP.
@@ -11,7 +11,6 @@
 # ---- Standard Library imports
 import os.path as osp
 from collections.abc import Mapping
-
 
 # ---- Third party imports
 import matplotlib.pyplot as plt
@@ -130,7 +129,6 @@ class HelpOutput(Mapping):
         print("Data saved successfully.")
 
     # ---- Calcul
-
     def calc_area_monthly_avg(self):
         """
         Calcul the monthly values of the water budget in mm/month for the

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
-# =============================================================================
-# Copyright © PyHelp Project Contributors
+# -----------------------------------------------------------------------------
+# Copyright © PyHELP Project Contributors
 # https://github.com/cgq-qgc/pyhelp
 #
-# This file is part of PyHelp.
+# This file is part of PyHELP.
 # Licensed under the terms of the MIT License.
-# =============================================================================
+# -----------------------------------------------------------------------------
 
-# ---- Standard Library Imports
+# ---- Standard library imports
 import os
 import os.path as osp
 
@@ -17,7 +17,7 @@ import numpy as np
 import pytest
 
 
-# ---- Local library Imports
+# ---- Local library imports
 from pyhelp import __rootdir__
 from pyhelp.managers import HelpManager
 from pyhelp.output import HelpOutput
@@ -36,8 +36,7 @@ def input_files(example_folder):
     return {'airtemp': osp.join(example_folder, 'airtemp_input_data.csv'),
             'precip': osp.join(example_folder, 'precip_input_data.csv'),
             'solrad': osp.join(example_folder, 'solrad_input_data.csv'),
-            'grid': osp.join(example_folder, 'input_grid.csv')
-            }
+            'grid': osp.join(example_folder, 'input_grid.csv')}
 
 
 @pytest.fixture(scope="module")
@@ -52,7 +51,7 @@ def helpm(example_folder):
 
 
 # =============================================================================
-# ---- Test HelpManager
+# ---- Tests
 # =============================================================================
 def test_autoread_input(helpm):
     """


### PR DESCRIPTION
Fixes #72

Grid pandas dataframe index and columns are now saved in HDF5 datasets instead of attributes.