### PR TITLE
PR: Change HelpOutput inheritance to "object" from "Mapping"

### DIFF
--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -27,7 +27,6 @@ class HelpOutput(object):
     """
 
     def __init__(self, path_or_dict: str | dict):
-        super().__init__()
         if isinstance(path_or_dict, dict):
             self.data = path_or_dict['data']
             self.grid = path_or_dict['grid']

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 # ---- Standard Library imports
 import os.path as osp
-from collections.abc import Mapping
+
+
 
 # ---- Third party imports
 import matplotlib.pyplot as plt
@@ -21,14 +22,14 @@ import h5py
 from scipy.stats import linregress
 
 
-class HelpOutput(Mapping):
+class HelpOutput(object):
     """
     A container to read and post-process monthly water budget results produced
     with the :class:`~pyhelp.HelpManager` class.
     """
 
     def __init__(self, path_or_dict: str | dict):
-        super(HelpOutput, self).__init__()
+        super().__init__()
         if isinstance(path_or_dict, dict):
             self.data = path_or_dict['data']
             self.grid = path_or_dict['grid']
@@ -37,15 +38,6 @@ class HelpOutput(Mapping):
         else:
             self.data = None
             self.grid = None
-
-    def __getitem__(self):
-        pass
-
-    def __iter__(self):
-        pass
-
-    def __len__(self):
-        return len(self.data['cid'])
 
     def load_from_hdf5(self, path_to_hdf5: str):
         """Read data and grid from an HDF5 file at the specified location."""

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 # ---- Standard Library imports
 import os.path as osp
 
-
-
 # ---- Third party imports
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -177,7 +175,6 @@ class HelpOutput(object):
                 for key in keys}
 
     # ---- Plots
-
     def _create_figure(self, fsize=None, margins=None):
         """
         Create and return a figure and an axe mpl object using the


### PR DESCRIPTION
There is no practical reason to make `HelpOutput` inherit from `Mapping`. It makes the code more confusing imo.