### PR TITLE
PR: Don't save the grid in HelpOutput

### DIFF
--- a/pyhelp/managers.py
+++ b/pyhelp/managers.py
@@ -532,16 +532,13 @@ def load_grid_from_csv(path_togrid):
     Load the csv that contains the infos required to evaluate regional
     groundwater recharge with HELP.
     """
-    grid = pd.read_csv(path_togrid)
+    grid = pd.read_csv(path_togrid, dtype={'cid': 'str'})
 
     fname = osp.basename(path_togrid)
-    req_keys = ['cid', 'lat_dd', 'lon_dd', 'run']
+    req_keys = ['cid', 'lat_dd', 'lon_dd', 'run', 'context']
     for key in req_keys:
         if key not in grid.keys():
-            raise KeyError("No attribute '%s' found in %s" % (key, fname))
-
-    # Make sure that cid is a str.
-    grid['cid'] = np.array(grid['cid']).astype(str)
+            raise KeyError("No attribute '{}' found in {}".format(key, fname))
 
     # Set 'cid' as the index of the dataframe.
     grid.set_index(['cid'], drop=False, inplace=True)

--- a/pyhelp/managers.py
+++ b/pyhelp/managers.py
@@ -374,8 +374,7 @@ class HelpManager(object):
 
         output_data = run_help_allcells(cellparams)
         output_data = self._post_process_output(output_data)
-        output_grid = self.grid.loc[output_data['cid']]
-        help_output = HelpOutput({'data': output_data, 'grid': output_grid})
+        help_output = HelpOutput(output_data)
         if path_to_hdf5:
             help_output.save_to_hdf5(path_to_hdf5)
 

--- a/pyhelp/managers.py
+++ b/pyhelp/managers.py
@@ -413,6 +413,8 @@ class HelpManager(object):
         data['cid'] = cellnames
         data['years'] = years
         data['idx_nan'] = []
+        data['lat_dd'] = self.grid.loc[cellnames]['lat_dd'].values
+        data['lon_dd'] = self.grid.loc[cellnames]['lon_dd'].values
 
         for i, cellname in enumerate(cellnames):
             print("\rPost-processing cell %d of %d..." % (i+1, Np), end=' ')

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -79,9 +79,10 @@ class HelpOutput(object):
         """
         print("Saving data to {}...".format(osp.basename(path_to_csv)))
         df = pd.DataFrame(index=self.data['cid'])
-        df['lat_dd'] = self.data['cid']
-        df['lon_dd'] = self.data['lon_dd']
         df.index.name = 'cid'
+
+        df['lat_dd'] = self.data['lat_dd']
+        df['lon_dd'] = self.data['lon_dd']
 
         yearly_avg = self.calc_cells_yearly_avg()
         for key, value in yearly_avg.items():

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -16,6 +16,7 @@ import os.path as osp
 import numpy as np
 import pandas as pd
 import pytest
+from pandas.api.types import is_string_dtype
 
 
 # ---- Local library imports
@@ -53,6 +54,12 @@ def helpm():
 # =============================================================================
 # ---- Tests
 # =============================================================================
+def test_read_input_grid(helpm, output_file):
+    """Test that the input grid is read as expected."""
+    assert is_string_dtype(helpm.grid.index)
+    assert is_string_dtype(helpm.grid['cid'])
+
+
 def test_calc_help_cells(helpm, output_file):
     """Test that the HelpManager is able to run water budget calculation."""
     cellnames = helpm.cellnames[:100]

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -117,7 +117,8 @@ def test_save_output_to_csv(output_dir, output_file):
     assert osp.exists(csvfilename)
 
     # Assert that the content of the csv is as expected.
-    df = pd.read_csv(csvfilename, index_col=0, dtype={'cid': 'str'})
+    df = pd.read_csv(csvfilename, dtype={'cid': 'str'})
+    df = df.set_index('cid', drop=True)
     assert list(df.columns) == [
         'lat_dd', 'lon_dd', 'precip', 'runoff', 'evapo', 'perco',
         'subrun1', 'subrun2', 'rechg']


### PR DESCRIPTION
Only save the `lat_dd` and `lon_dd` instead of the whole grid in the `HelpOutput`.

Added a test for `HelpOutput.save_to_csv`