### PR TITLE
PR: Add the possibility to calcul yearly averages over a given period of time.

### DIFF
--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -128,15 +128,26 @@ class HelpOutput(object):
         keys = list(monthly_avg.keys())
         return {key: np.sum(monthly_avg[key], axis=1) for key in keys}
 
-    def calc_cells_yearly_avg(self,
-                              year_min: int = -np.inf,
+    def calc_cells_yearly_avg(self, year_min: int = -np.inf,
                               year_max: int = np.inf) -> dict:
         """
         Calcul the water budget average yearly values for each cell.
 
-        Return a dictionary that contains a numpy array for each
-        component of the water budget with average values calculated for
-        each cell for which data are available.
+        Parameters
+        ----------
+        year_min : int, optional
+            Minimum year of the period over which the average annual values
+            are calculated . The default is -np.inf.
+        year_max : int, optional
+            Maximum year of the period over which the average annual values
+            are calculated . The default is np.inf.
+
+        Returns
+        -------
+        dict
+           A dictionary that contains, for each component of the water budget,
+           a numpy array of the average yearly values calculated for each cell
+           of the grid.
         """
         years_mask = (
             (self.data['years'] >= year_min) &

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -75,10 +75,12 @@ class HelpOutput(object):
             hdf5file.close()
         print("Data saved successfully.")
 
-    def save_to_csv(self, path_to_csv):
+    def save_to_csv(self, path_to_csv: str,
+                    year_min: int = -np.inf,
+                    year_max: int = np.inf) -> None:
         """
-        Save the grid data and cell yearly average values for each component
-        of the water budget to a csv file.
+        Save in a csv file the annual average values of the components of the
+        water budget calculated for each cell of the grid.
         """
         print("Saving data to {}...".format(osp.basename(path_to_csv)))
         df = pd.DataFrame(index=self.data['cid'])
@@ -87,7 +89,7 @@ class HelpOutput(object):
         df['lat_dd'] = self.data['lat_dd']
         df['lon_dd'] = self.data['lon_dd']
 
-        yearly_avg = self.calc_cells_yearly_avg()
+        yearly_avg = self.calc_cells_yearly_avg(year_min, year_max)
         for key, value in yearly_avg.items():
             df[key] = value
 

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -126,20 +126,25 @@ class HelpOutput(object):
         keys = list(monthly_avg.keys())
         return {key: np.sum(monthly_avg[key], axis=1) for key in keys}
 
-    def calc_cells_yearly_avg(self):
+    def calc_cells_yearly_avg(self,
+                              year_min: int = -np.inf,
+                              year_max: int = np.inf) -> dict:
         """
-        Plot the yearly values of the water budget in mm/year for the whole
-        study area.
-        Calcul water budget average yearly values for each cell.
+        Calcul the water budget average yearly values for each cell.
 
         Return a dictionary that contains a numpy array for each
         component of the water budget with average values calculated for
         each cell for which data are available.
         """
-        keys = ['precip', 'runoff', 'evapo', 'perco',
-                'subrun1', 'subrun2', 'rechg']
-        return {key: np.mean(np.sum(self.data[key], axis=2), axis=1)
-                for key in keys}
+        years_mask = (
+            (self.data['years'] >= year_min) &
+            (self.data['years'] <= year_max))
+
+        yearly_avg = {}
+        for varname in VARNAMES:
+            vardata = self.data[varname][:, years_mask, :]
+            yearly_avg[varname] = np.mean(np.sum(vardata, axis=2), axis=1)
+        return yearly_avg
 
     # ---- Plots
     def _create_figure(self, fsize=None, margins=None):

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -19,6 +19,9 @@ import numpy as np
 import h5py
 from scipy.stats import linregress
 
+VARNAMES = ['precip', 'runoff', 'evapo', 'perco',
+            'subrun1', 'subrun2', 'rechg']
+
 
 class HelpOutput(object):
     """

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -76,11 +76,20 @@ class HelpOutput(object):
         print("Data saved successfully.")
 
     def save_to_csv(self, path_to_csv: str,
-                    year_min: int = -np.inf,
-                    year_max: int = np.inf) -> None:
+                    year_from: int = -np.inf,
+                    year_to: int = np.inf) -> None:
         """
         Save in a csv file the annual average values of the components of the
         water budget calculated for each cell of the grid.
+
+        Parameters
+        ----------
+        year_from : int, optional
+            Year from which the average annual values are calculated.
+            The default is -np.inf.
+        year_to : int, optional
+            Year to which the average annual values are calculated.
+            The default is np.inf.
         """
         print("Saving data to {}...".format(osp.basename(path_to_csv)))
         df = pd.DataFrame(index=self.data['cid'])
@@ -89,7 +98,7 @@ class HelpOutput(object):
         df['lat_dd'] = self.data['lat_dd']
         df['lon_dd'] = self.data['lon_dd']
 
-        yearly_avg = self.calc_cells_yearly_avg(year_min, year_max)
+        yearly_avg = self.calc_cells_yearly_avg(year_from, year_to)
         for key, value in yearly_avg.items():
             df[key] = value
 
@@ -128,19 +137,19 @@ class HelpOutput(object):
         keys = list(monthly_avg.keys())
         return {key: np.sum(monthly_avg[key], axis=1) for key in keys}
 
-    def calc_cells_yearly_avg(self, year_min: int = -np.inf,
-                              year_max: int = np.inf) -> dict:
+    def calc_cells_yearly_avg(self, year_from: int = -np.inf,
+                              year_to: int = np.inf) -> dict:
         """
         Calcul the water budget average yearly values for each cell.
 
         Parameters
         ----------
-        year_min : int, optional
-            Minimum year of the period over which the average annual values
-            are calculated . The default is -np.inf.
-        year_max : int, optional
-            Maximum year of the period over which the average annual values
-            are calculated . The default is np.inf.
+        year_from : int, optional
+            Year from which the average annual values are calculated.
+            The default is -np.inf.
+        year_to : int, optional
+            Year to which the average annual values are calculated.
+            The default is np.inf.
 
         Returns
         -------
@@ -150,8 +159,8 @@ class HelpOutput(object):
            of the grid.
         """
         years_mask = (
-            (self.data['years'] >= year_min) &
-            (self.data['years'] <= year_max))
+            (self.data['years'] >= year_from) &
+            (self.data['years'] <= year_to))
 
         yearly_avg = {}
         for varname in VARNAMES:

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -67,9 +67,7 @@ def test_calc_help_cells(helpm, output_file):
     helpm.calc_help_cells(output_file, cellnames, tfsoil=-3)
     assert osp.exists(output_file)
 
-
-def test_validate_results(output_file):
-    """Test that the water budget results are as expected. """
+    # Assert that the results are as expected.
     output = HelpOutput(output_file)
     area_yrly_avg = output.calc_area_yearly_avg()
     expected_results = {'precip': 11614.46,
@@ -154,7 +152,7 @@ def test_calc_cells_yearly_avg(output_file):
 
 def test_save_output_to_csv(output_dir, output_file):
     """
-    Test that saving yarly results to csv is working as expected.
+    Test that saving yearly results to csv is working as expected.
     """
     output = HelpOutput(output_file)
 

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -110,7 +110,7 @@ def test_calc_cells_yearly_avg(output_file):
     output = HelpOutput(output_file)
 
     # Test calc_cells_yearly_avg without providing any value for the
-    # year_min ad year_max argument.
+    # year_from and year_to argument.
     yearly_avg = output.calc_cells_yearly_avg()
     expected_results = {
         'precip': 1055.8597373343132,
@@ -124,8 +124,8 @@ def test_calc_cells_yearly_avg(output_file):
         result = np.sum(yearly_avg[varname]) / len(yearly_avg[varname])
         assert abs(result - expected_results[varname]) < 1, varname
 
-    # Test calc_cells_yearly_avg with non null year_min and year_max argument.
-    yearly_avg = output.calc_cells_yearly_avg(year_min=2003, year_max=2009)
+    # Test calc_cells_yearly_avg with non null year_from and year_to argument.
+    yearly_avg = output.calc_cells_yearly_avg(year_from=2003, year_to=2009)
     expected_results = {
         'precip': 1086.8448950125246,
         'perco': 259.85654385728577,
@@ -138,8 +138,8 @@ def test_calc_cells_yearly_avg(output_file):
         result = np.sum(yearly_avg[varname]) / len(yearly_avg[varname])
         assert abs(result - expected_results[varname]) < 1, varname
 
-    # Test calc_cells_yearly_avg with year_min == year_max.
-    yearly_avg = output.calc_cells_yearly_avg(year_min=2003, year_max=2003)
+    # Test calc_cells_yearly_avg with year_from == year_to.
+    yearly_avg = output.calc_cells_yearly_avg(year_from=2003, year_to=2003)
     expected_results = {
         'precip': 1144.4142919267927,
         'perco': 324.15252048559057,

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -104,6 +104,54 @@ def test_plot_water_budget(output_dir, output_file):
     assert osp.exists(figfilename)
 
 
+def test_calc_cells_yearly_avg(output_file):
+    """
+    Test that the method to calculate cells yearly average values is
+    working as expected.
+    """
+    output = HelpOutput(output_file)
+
+    # Test calc_cells_yearly_avg without providing any value for the
+    # year_min ad year_max argument.
+    yearly_avg = output.calc_cells_yearly_avg()
+    expected_results = {
+        'precip': 1055.8597373343132,
+        'perco': 251.5843470406275,
+        'evapo': 548.5954285729573,
+        'rechg': 130.18263914385366,
+        'runoff': 212.26214164981408,
+        'subrun1': 46.26946108344004,
+        'subrun2': 113.02721698440918}
+    for varname in list(expected_results.keys()):
+        result = np.sum(yearly_avg[varname]) / len(yearly_avg[varname])
+        assert abs(result - expected_results[varname]) < 1, varname
+
+    # Test calc_cells_yearly_avg with non null year_min and year_max argument.
+    yearly_avg = output.calc_cells_yearly_avg(year_min=2003, year_max=2009)
+    expected_results = {
+        'precip': 1086.8448950125246,
+        'perco': 259.85654385728577,
+        'evapo': 550.11140519815,
+        'rechg': 136.12068516893297,
+        'runoff': 226.9635476845988,
+        'subrun1': 47.97935577404126,
+        'subrun2': 121.66539490800443}
+    for varname in list(expected_results.keys()):
+        result = np.sum(yearly_avg[varname]) / len(yearly_avg[varname])
+        assert abs(result - expected_results[varname]) < 1, varname
+
+    # Test calc_cells_yearly_avg with year_min == year_max.
+    yearly_avg = output.calc_cells_yearly_avg(year_min=2003, year_max=2003)
+    expected_results = {
+        'precip': 1144.4142919267927,
+        'perco': 324.15252048559057,
+        'evapo': 492.4243657442988,
+        'rechg': 148.72946963740077,
+        'runoff': 164.32582637467374,
+        'subrun1': 56.33706154407843,
+        'subrun2': 140.96849990912418}
+
+
 def test_save_output_to_csv(output_dir, output_file):
     """
     Test that saving yarly results to csv is working as expected.


### PR DESCRIPTION
Add the `year_from` and `year_to` args to both methods:

- `HelpOutput.save_to_csv( path_to_csv: str, year_from: int = -np.inf, year_to: int = np.inf)`

- `HelpOutput.calc_cells_yearly_avg(year_from: int = -np.inf, year_to: int = np.inf)`

where

`year_from` : Year from which the average annual values are calculated.
`year_to` : Year to which the average annual values are calculated.

