### PR TITLE
PR: Add options to specify a period in water budget plots

### DIFF
--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -282,7 +282,7 @@ class HelpOutput(object):
         Plot the average yearly values of the water budget in mm/year
         for the whole study area.
         """
-        fig, ax = self._create_figure(fsize=(8.5, 5))
+        fig, ax = self._create_figure(fsize=(9, 5))
 
         text_offset = transforms.ScaledTranslation(
             0, 3/72, fig.dpi_scale_trans)
@@ -308,8 +308,6 @@ class HelpOutput(object):
             bbox = bbox.transformed(ax.transData.inverted())
             ymax = max(ymax, bbox.y1)
         ymax = np.ceil(ymax * 1.025)
-        print(ymax)
-        
         ax.axis(ymin=0, ymax=ymax, xmin=0.25, xmax=6.75)
 
         ax.grid(axis='y', color=[0.35, 0.35, 0.35], ls='-', lw=0.5)

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -22,7 +22,8 @@ import h5py
 from scipy.stats import linregress
 
 
-VARNAMES = ['precip', 'rechg', 'runoff', 'evapo', 'subrun1', 'subrun2']
+VARNAMES = ['precip', 'rechg', 'runoff', 'evapo',
+            'subrun1', 'subrun2', 'perco']
 LABELS = {'precip': "Précipitations totales",
           'rechg': "Recharge au roc",
           'runoff': "Ruissellement de surface",
@@ -255,7 +256,7 @@ class HelpOutput(object):
         fig, ax = self._create_figure(fsize=(9, 6.5))
 
         months = list(range(1, 13))
-        for varname in VARNAMES:
+        for varname in VARNAMES[:-1]:
             vardataf = avg_monthly[varname]
             yearmask = (
                 (vardataf.index >= year_from) &
@@ -320,7 +321,7 @@ class HelpOutput(object):
         area_yearly_avg = self.calc_area_yearly_avg()
         x = 0
         text_handles = []
-        for varname in VARNAMES:
+        for varname in VARNAMES[:-1]:
             x += 1
 
             vardataf = area_yearly_avg[varname]
@@ -398,7 +399,7 @@ class HelpOutput(object):
         yearly_avg = self.calc_area_yearly_avg()
         mask_years = (years >= year_from) & (years <= year_to)
 
-        for varname in VARNAMES:
+        for varname in VARNAMES[:-1]:
             masked_data = yearly_avg[varname].loc[mask_years]
             masked_years = masked_data.index.values.astype('int')
 

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -251,7 +251,7 @@ class HelpOutput(object):
         months = list(range(1, 13))
         for varname, label in zip(VARNAMES, LABELS):
             ax.plot(months, np.mean(avg_monthly[varname], axis=0),
-                    marker='o', mec='white', clip_on=False, lw=2,
+                    marker=None, mec='white', clip_on=False, lw=2,
                     label=label)
 
         ax.set_ylabel('Moyennes mensuelles (mm/mois)',

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -238,7 +238,7 @@ class HelpOutput(object):
         l6, = ax.plot(months, np.mean(avg_monthly['subrun2'], axis=0),
                       marker='o', mec='white', clip_on=False, lw=2)
 
-        ax.set_ylabel('Composantes du bilan hydrologique\n(mm/mois)',
+        ax.set_ylabel('Moyennes mensuelles (mm/mois)',
                       fontsize=16, labelpad=10)
         ax.set_xlabel('Mois', fontsize=16, labelpad=10)
         ax.axis(ymin=-5)

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -281,15 +281,23 @@ class HelpOutput(object):
             numpoints=1, fontsize=12, frameon=False, borderaxespad=0,
             loc='lower left', borderpad=0.5, bbox_to_anchor=(0, 1), ncol=2)
 
-        # Setup xlabel.
+        # Add note about year considered for the hydrologic budget.
         masked_years = self.data['years'][mask_years]
         year_min = masked_years.min()
         year_max = masked_years.max()
         if year_min == year_max:
-            text = f"{year_min:0.0f}"
+            text = f"Année considérée pour le bilan : {year_min:0.0f}"
         else:
-            text = f"{year_min:0.0f} - {year_max:0.0f}"
-        ax.set_xlabel(text, fontsize=16, labelpad=10)
+            text = "Années considérées pour le bilan : "
+            text += f"{year_min:0.0f} - {year_max:0.0f}"
+
+        fig.canvas.draw()
+        bbox_bottom, _ = ax.xaxis.get_ticklabel_extents(
+            fig.canvas.get_renderer())
+        y0 = ax.transAxes.inverted().transform(bbox_bottom)[0][1]
+        offset = transforms.ScaledTranslation(0, -12/72, fig.dpi_scale_trans)
+        ax.text(0, y0, text, transform=ax.transAxes + offset,
+                va='top', ha='left')
 
         fig.tight_layout()
 
@@ -369,20 +377,28 @@ class HelpOutput(object):
             fontsize=16, labelpad=10)
         ax.set_xticklabels([])
 
-        # Setup xlabel.
-        masked_years = self.data['years'][mask_years]
-        year_min = masked_years.min()
-        year_max = masked_years.max()
-        if year_min == year_max:
-            text = f"{year_min:0.0f}"
-        else:
-            text = f"{year_min:0.0f} - {year_max:0.0f}"
-        ax.set_xlabel(text, fontsize=16, labelpad=10)
-
         ax.legend(
             numpoints=1, fontsize=12, frameon=False, borderaxespad=0,
             loc='lower left', borderpad=0.5, bbox_to_anchor=(0, 1, 1, 1),
             ncol=2)
+
+        # Add note about year considered for the hydrologic budget.
+        masked_years = self.data['years'][mask_years]
+        year_min = masked_years.min()
+        year_max = masked_years.max()
+        if year_min == year_max:
+            text = f"Année considérée pour le bilan : {year_min:0.0f}"
+        else:
+            text = "Années considérées pour le bilan : "
+            text += f"{year_min:0.0f} - {year_max:0.0f}"
+
+        fig.canvas.draw()
+        bbox_bottom, _ = ax.xaxis.get_ticklabel_extents(
+            fig.canvas.get_renderer())
+        y0 = ax.transAxes.inverted().transform(bbox_bottom)[0][1]
+        offset = transforms.ScaledTranslation(0, -6/72, fig.dpi_scale_trans)
+        ax.text(0, y0, text, transform=ax.transAxes + offset,
+                va='top', ha='left')
 
         fig.tight_layout()
 

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -180,9 +180,9 @@ class HelpOutput(object):
         # Setup figure size.
         if fsize is not None:
             fwidth, fheight = fsize
+            fig.set_size_inches(*fsize)
         else:
             fwidth, fheight = fig.get_size_inches()
-        fig.set_size_inches(*fsize)
 
         # Setup axe margins.
         if margins is not None:
@@ -190,9 +190,9 @@ class HelpOutput(object):
             top_margin = margins[1]/fheight
             right_margin = margins[2]/fwidth
             bot_margin = margins[3]/fheight
-        ax.set_position([left_margin, bot_margin,
-                         1 - left_margin - right_margin,
-                         1 - top_margin - bot_margin])
+            ax.set_position([left_margin, bot_margin,
+                             1 - left_margin - right_margin,
+                             1 - top_margin - bot_margin])
 
         return fig, ax
 
@@ -202,8 +202,6 @@ class HelpOutput(object):
         """
         Plot the monthly average values of the water budget in mm/month
         for the whole study area.
-        fig, ax = self._create_figure(
-            fsize=(9, 6.5), margins=(1.5, 1, 0.25, 0.7))
 
         Parameters
         ----------

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -345,7 +345,7 @@ class HelpOutput(object):
             bbox = handle.get_window_extent(fig.canvas.get_renderer())
             bbox = bbox.transformed(ax.transData.inverted())
             ymax = max(ymax, bbox.y1)
-        ymax = np.ceil(ymax * 1.025)
+        ymax = np.ceil(ymax * 1.05)
         ax.axis(ymin=0, ymax=ymax, xmin=0.25, xmax=6.75)
 
         ax.grid(axis='y', color=[0.35, 0.35, 0.35], ls='-', lw=0.5)

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -14,6 +14,7 @@ import os.path as osp
 
 # ---- Third party imports
 from matplotlib.figure import Figure
+from matplotlib import transforms
 import matplotlib.pyplot as plt
 import pandas as pd
 import numpy as np
@@ -283,15 +284,23 @@ class HelpOutput(object):
         """
         fig, ax = self._create_figure(fsize=(8, 6.5))
 
+        text_offset = transforms.ScaledTranslation(
+            0, 3/72, fig.dpi_scale_trans)
+
         area_yearly_avg = self.calc_area_yearly_avg()
         x = 0
+        text_handles = []
         for varname, label in zip(VARNAMES, LABELS):
             x += 1
             var_avg_yearly = area_yearly_avg[varname].mean()
             ax.bar(x, var_avg_yearly, 0.85, align='center',
                    label=label)
-            ax.text(x, var_avg_yearly + 10, "%d\nmm/an" % var_avg_yearly,
-                    ha='center', va='bottom')
+            text_handles.append(
+                ax.text(x, var_avg_yearly, "%d\nmm/an" % var_avg_yearly,
+                        ha='center', va='bottom',
+                        transform=ax.transData + text_offset))
+        fig.canvas.draw()
+
 
         ax.axis(ymin=0, ymax=1200, xmin=0, xmax=7)
         ax.grid(axis='y', color=[0.35, 0.35, 0.35], ls='-', lw=0.5)

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -20,8 +20,14 @@ import numpy as np
 import h5py
 from scipy.stats import linregress
 
-VARNAMES = ['precip', 'runoff', 'evapo', 'perco',
-            'subrun1', 'subrun2', 'rechg']
+
+VARNAMES = ['precip', 'rechg', 'runoff', 'evapo', 'subrun1', 'subrun2']
+LABELS = ["Précipitations totales",
+          "Recharge au roc",
+          "Ruissellement de surface",
+          "Évapotranspiration",
+          "Ruissellement hypodermique superficiel",
+          "Ruissellement hypodermique profond"]
 
 
 class HelpOutput(object):
@@ -242,14 +248,7 @@ class HelpOutput(object):
         fig, ax = self._create_figure(fsize=(9, 6.5))
 
         months = list(range(1, 13))
-        varnames = ['precip', 'rechg', 'runoff', 'evapo', 'subrun1', 'subrun2']
-        labels = ["Précipitations totales",
-                  "Recharge au roc",
-                  "Ruissellement de surface",
-                  "Évapotranspiration",
-                  "Ruissellement hypodermique superficiel",
-                  "Ruissellement hypodermique profond"]
-        for varname, label in zip(varnames, labels):
+        for varname, label in zip(VARNAMES, LABELS):
             ax.plot(months, np.mean(avg_monthly[varname], axis=0),
                     marker='o', mec='white', clip_on=False, lw=2,
                     label=label)

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -224,19 +224,21 @@ class HelpOutput(object):
             The matplotlib figure instance created by this method.
         """
         avg_monthly = self.calc_area_monthly_avg()
-        months = range(1, 13)
-        l1, = ax.plot(months, np.mean(avg_monthly['precip'], axis=0),
-                      marker='o', mec='white', clip_on=False, lw=2)
-        l2, = ax.plot(months, np.mean(avg_monthly['rechg'], axis=0),
-                      marker='o', mec='white', clip_on=False, lw=2)
-        l3, = ax.plot(months, np.mean(avg_monthly['runoff'], axis=0),
-                      marker='o', mec='white', clip_on=False, lw=2)
-        l4, = ax.plot(months, np.mean(avg_monthly['evapo'], axis=0),
-                      marker='o', mec='white', clip_on=False, lw=2)
-        l5, = ax.plot(months, np.mean(avg_monthly['subrun1'], axis=0),
-                      marker='o', mec='white', clip_on=False, lw=2)
-        l6, = ax.plot(months, np.mean(avg_monthly['subrun2'], axis=0),
-                      marker='o', mec='white', clip_on=False, lw=2)
+
+        fig, ax = self._create_figure(fsize=(9, 6.5))
+
+        months = list(range(1, 13))
+        varnames = ['precip', 'rechg', 'runoff', 'evapo', 'subrun1', 'subrun2']
+        labels = ["Précipitations totales",
+                  "Recharge au roc",
+                  "Ruissellement de surface",
+                  "Évapotranspiration",
+                  "Ruissellement hypodermique superficiel",
+                  "Ruissellement hypodermique profond"]
+        for varname, label in zip(varnames, labels):
+            ax.plot(months, np.mean(avg_monthly[varname], axis=0),
+                    marker='o', mec='white', clip_on=False, lw=2,
+                    label=label)
 
         ax.set_ylabel('Moyennes mensuelles (mm/mois)',
                       fontsize=16, labelpad=10)
@@ -244,19 +246,17 @@ class HelpOutput(object):
         ax.axis(ymin=-5)
         ax.grid(axis='both', color=[0.35, 0.35, 0.35], ls='-', lw=0.5)
         ax.set_xticks(months)
+
+        # http://bdl.oqlf.gouv.qc.ca/bdl/gabarit_bdl.asp?id=3619
         ax.set_xticklabels(['Jan', 'Fév', 'Mar', 'Avr', 'Mai', 'Jun', 'Jul',
                             'Aoû', 'Sep', 'Oct', 'Nov', 'Déc'])
         ax.tick_params(axis='both', direction='out', labelsize=12)
 
-        lines = [l1, l2, l3, l4, l5, l6]
-        labels = ["Précipitations totales", "Recharge au roc",
-                  "Ruissellement de surface", "Évapotranspiration",
-                  "Ruissellement hypodermique superficiel",
-                  "Ruissellement hypodermique profond"]
-        legend = ax.legend(lines, labels, numpoints=1, fontsize=12,
-                           borderaxespad=0, loc='lower left', borderpad=0.5,
-                           bbox_to_anchor=(0, 1), ncol=2)
-        legend.draw_frame(False)
+        ax.legend(
+            numpoints=1, fontsize=12, frameon=False, borderaxespad=0,
+            loc='lower left', borderpad=0.5, bbox_to_anchor=(0, 1), ncol=2)
+
+        fig.tight_layout()
 
         if figname is not None:
             fig.savefig(figname)

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -109,21 +109,33 @@ class HelpOutput(object):
     # ---- Calcul
     def calc_area_monthly_avg(self):
         """
-        Calcul the monthly values of the water budget in mm/month for the
+        Calcul the water budget average monthly values in mm/month for the
         whole study area.
 
-        Return a dictionary that contains a 2D numpy array for each
-        component of the water budget with average values calculated over
-        the study area for each month of every year for which data is
-        available.
+        Returns
+        -------
+        dict
+            A dictionary that contains a pandas dataframe for each
+            component of the water budget with monthly average values
+            calculated over the whole study area for each month (columns) and
+            every year (index) for which data is available.
         """
         Np = len(self.data['cid']) - len(self.data['idx_nan'])
-        keys = ['precip', 'runoff', 'evapo', 'perco',
-                'subrun1', 'subrun2', 'rechg']
-        if self.data is None:
-            return {key: np.zeros((1, 12)) for key in keys}
-        else:
-            return {key: np.nansum(self.data[key], axis=0)/Np for key in keys}
+
+        monthly_avg = {}
+        for varname in VARNAMES:
+            if self.data is None:
+                df = pd.DataFrame(
+                    columns=list(range(1, 13)))
+            else:
+                df = pd.DataFrame(
+                    data=np.nansum(self.data[varname], axis=0) / Np,
+                    index=self.data['years'],
+                    columns=list(range(1, 13)))
+            df.columns.name = 'month'
+            df.index.name = 'year'
+            monthly_avg[varname] = df
+        return monthly_avg
 
     def calc_area_yearly_avg(self):
         """

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import os.path as osp
 
 # ---- Third party imports
+from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 import pandas as pd
 import numpy as np
@@ -201,10 +202,27 @@ class HelpOutput(object):
         """
         Plot the monthly average values of the water budget in mm/month
         for the whole study area.
-        """
         fig, ax = self._create_figure(
             fsize=(9, 6.5), margins=(1.5, 1, 0.25, 0.7))
 
+        Parameters
+        ----------
+        figname : str, optional
+            The abolute path of the file where to save the figure to disk.
+            Note that the format of the file is inferred from the extension of
+            "figname".
+        year_from : int, optional
+            Year from which the average monthly values are calculated.
+            The default is -np.inf.
+        year_to : int, optional
+            Year to which the average monthly values are calculated.
+            The default is np.inf.
+
+        Returns
+        -------
+        Figure
+            The matplotlib figure instance created by this method.
+        """
         avg_monthly = self.calc_area_monthly_avg()
         months = range(1, 13)
         l1, = ax.plot(months, np.mean(avg_monthly['precip'], axis=0),

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -265,8 +265,9 @@ class HelpOutput(object):
                     marker='o', ms=5, mec='white', clip_on=False, lw=2,
                     label=LABELS[varname], color=COLORS[varname])
 
-        ax.set_ylabel('Moyennes mensuelles (mm/mois)',
-                      fontsize=16, labelpad=10)
+        ax.set_ylabel(
+            'Composantes mensuelles moyennes\ndu bilan hydrologique (mm/mois)',
+            fontsize=16, labelpad=10)
         ax.set_xlabel('Mois', fontsize=16, labelpad=10)
         ax.axis(ymin=-5)
         ax.grid(axis='y', color=[0.35, 0.35, 0.35], ls='-', lw=0.5)
@@ -352,7 +353,9 @@ class HelpOutput(object):
 
         ax.tick_params(axis='y', direction='out', labelsize=12)
         ax.tick_params(axis='x', direction='out', length=0)
-        ax.set_ylabel('Moyennes annuelles (mm/an)', fontsize=16, labelpad=10)
+        ax.set_ylabel(
+            'Composantes annuelles moyennes\ndu bilan hydrologique (mm/an)',
+            fontsize=16, labelpad=10)
         ax.set_xticklabels([])
 
         ax.legend(

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -139,16 +139,20 @@ class HelpOutput(object):
 
     def calc_area_yearly_avg(self):
         """
-        Calcul the average yearly values of the water budget in mm/year
-        for the whole study area.
+        Calcul the water budget average yearly values in mm/year for the
+        whole study area.
 
-        Return a dictionary that contains a numpy array for each
-        component of the water budget with average values calculated over
-        the study area for every year for which data is available.
+        Returns
+        -------
+        dict
+            A dictionary that contains pandas dataframe for each
+            component of the water budget with with yearly average values
+            calculated over the whole study area for each year (index) for
+            which data is available.
         """
         monthly_avg = self.calc_area_monthly_avg()
-        keys = list(monthly_avg.keys())
-        return {key: np.sum(monthly_avg[key], axis=1) for key in keys}
+        return {varname: monthly_avg[varname].sum(axis=1) for
+                varname in VARNAMES}
 
     def calc_cells_yearly_avg(self, year_from: int = -np.inf,
                               year_to: int = np.inf) -> dict:

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -262,7 +262,7 @@ class HelpOutput(object):
                 (vardataf.index >= year_from) &
                 (vardataf.index <= year_to))
             ax.plot(months, vardataf.loc[yearmask, :].mean(axis=0),
-                    marker='o', mec='white', clip_on=False, lw=2,
+                    marker='o', ms=5, mec='white', clip_on=False, lw=2,
                     label=LABELS[varname], color=COLORS[varname])
 
         ax.set_ylabel('Moyennes mensuelles (mm/mois)',
@@ -403,7 +403,7 @@ class HelpOutput(object):
             masked_data = yearly_avg[varname].loc[mask_years]
             masked_years = masked_data.index.values.astype('int')
 
-            ax.plot(masked_years, masked_data, marker='o', mec='white',
+            ax.plot(masked_years, masked_data, marker='o', mec='white', ms=5,
                     clip_on=False, lw=2, color=COLORS[varname],
                     label=LABELS[varname])
 

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -29,6 +29,7 @@ LABELS = ["Précipitations totales",
           "Évapotranspiration",
           "Ruissellement hypodermique superficiel",
           "Ruissellement hypodermique profond"]
+COLORS = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b']
 
 
 class HelpOutput(object):
@@ -249,14 +250,14 @@ class HelpOutput(object):
         fig, ax = self._create_figure(fsize=(9, 6.5))
 
         months = list(range(1, 13))
-        for varname, label in zip(VARNAMES, LABELS):
+        for varname, label, color in zip(VARNAMES, LABELS, COLORS):
             vardataf = avg_monthly[varname]
             yearmask = (
                 (vardataf.index >= year_from) &
                 (vardataf.index <= year_to))
             ax.plot(months, vardataf.loc[yearmask, :].mean(axis=0),
                     marker='o', mec='white', clip_on=False, lw=2,
-                    label=label)
+                    label=label, color=color)
 
         ax.set_ylabel('Moyennes mensuelles (mm/mois)',
                       fontsize=16, labelpad=10)
@@ -314,7 +315,7 @@ class HelpOutput(object):
         area_yearly_avg = self.calc_area_yearly_avg()
         x = 0
         text_handles = []
-        for varname, label in zip(VARNAMES, LABELS):
+        for varname, label, color in zip(VARNAMES, LABELS, COLORS):
             x += 1
 
             vardataf = area_yearly_avg[varname]
@@ -324,7 +325,7 @@ class HelpOutput(object):
             var_avg_yearly = vardataf.loc[yearmask].mean()
 
             ax.bar(x, var_avg_yearly, 0.85, align='center',
-                   label=label)
+                   label=label, color=color)
             text_handles.append(
                 ax.text(x, var_avg_yearly, "%d\nmm/an" % var_avg_yearly,
                         ha='center', va='bottom',

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -333,7 +333,7 @@ class HelpOutput(object):
             ax.bar(x, var_avg_yearly, 0.85, align='center',
                    label=LABELS[varname], color=COLORS[varname])
             text_handles.append(
-                ax.text(x, var_avg_yearly, "%d\nmm/an" % var_avg_yearly,
+                ax.text(x, var_avg_yearly, "%d\nmm/an" % round(var_avg_yearly),
                         ha='center', va='bottom',
                         transform=ax.transData + text_offset))
         fig.canvas.draw()

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -281,10 +281,30 @@ class HelpOutput(object):
 
         return fig
 
-    def plot_area_yearly_avg(self, figname=None):
+    def plot_area_yearly_avg(self, figname: str = None,
+                             year_from: int = -np.inf,
+                             year_to: int = np.inf) -> Figure:
         """
-        Plot the average yearly values of the water budget in mm/year
+        Plot the yearly average values of the water budget in mm/year
         for the whole study area.
+
+        Parameters
+        ----------
+        figname : str, optional
+            The abolute path of the file where to save the figure to disk.
+            Note that the format of the file is inferred from the extension of
+            "figname".
+        year_from : int, optional
+            Year from which the average yearly values are calculated.
+            The default is -np.inf.
+        year_to : int, optional
+            Year to which the average yearly values are calculated.
+            The default is np.inf.
+
+        Returns
+        -------
+        Figure
+            The matplotlib figure instance created by this method.
         """
         fig, ax = self._create_figure(fsize=(9, 5))
 
@@ -296,7 +316,13 @@ class HelpOutput(object):
         text_handles = []
         for varname, label in zip(VARNAMES, LABELS):
             x += 1
-            var_avg_yearly = area_yearly_avg[varname].mean()
+
+            vardataf = area_yearly_avg[varname]
+            yearmask = (
+                (vardataf.index >= year_from) &
+                (vardataf.index <= year_to))
+            var_avg_yearly = vardataf.loc[yearmask].mean()
+
             ax.bar(x, var_avg_yearly, 0.85, align='center',
                    label=label)
             text_handles.append(
@@ -331,6 +357,8 @@ class HelpOutput(object):
 
         if figname is not None:
             fig.savefig(figname)
+
+        return fig
 
     def plot_area_yearly_series(self, figname=None):
         """

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -23,13 +23,18 @@ from scipy.stats import linregress
 
 
 VARNAMES = ['precip', 'rechg', 'runoff', 'evapo', 'subrun1', 'subrun2']
-LABELS = ["Précipitations totales",
-          "Recharge au roc",
-          "Ruissellement de surface",
-          "Évapotranspiration",
-          "Ruissellement hypodermique superficiel",
-          "Ruissellement hypodermique profond"]
-COLORS = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b']
+LABELS = {'precip': "Précipitations totales",
+          'rechg': "Recharge au roc",
+          'runoff': "Ruissellement de surface",
+          'evapo': "Évapotranspiration",
+          'subrun1': "Ruissellement hypodermique superficiel",
+          'subrun2': "Ruissellement hypodermique profond"}
+COLORS = {'precip': '#1f77b4',
+          'rechg': '#ff7f0e',
+          'runoff': '#2ca02c',
+          'evapo': '#d62728',
+          'subrun1': '#9467bd',
+          'subrun2': '#8c564b'}
 
 
 class HelpOutput(object):
@@ -250,14 +255,14 @@ class HelpOutput(object):
         fig, ax = self._create_figure(fsize=(9, 6.5))
 
         months = list(range(1, 13))
-        for varname, label, color in zip(VARNAMES, LABELS, COLORS):
+        for varname in VARNAMES:
             vardataf = avg_monthly[varname]
             yearmask = (
                 (vardataf.index >= year_from) &
                 (vardataf.index <= year_to))
             ax.plot(months, vardataf.loc[yearmask, :].mean(axis=0),
                     marker='o', mec='white', clip_on=False, lw=2,
-                    label=label, color=color)
+                    label=LABELS[varname], color=COLORS[varname])
 
         ax.set_ylabel('Moyennes mensuelles (mm/mois)',
                       fontsize=16, labelpad=10)
@@ -315,7 +320,7 @@ class HelpOutput(object):
         area_yearly_avg = self.calc_area_yearly_avg()
         x = 0
         text_handles = []
-        for varname, label, color in zip(VARNAMES, LABELS, COLORS):
+        for varname in VARNAMES:
             x += 1
 
             vardataf = area_yearly_avg[varname]
@@ -325,7 +330,7 @@ class HelpOutput(object):
             var_avg_yearly = vardataf.loc[yearmask].mean()
 
             ax.bar(x, var_avg_yearly, 0.85, align='center',
-                   label=label, color=color)
+                   label=LABELS[varname], color=COLORS[varname])
             text_handles.append(
                 ax.text(x, var_avg_yearly, "%d\nmm/an" % var_avg_yearly,
                         ha='center', va='bottom',
@@ -393,19 +398,20 @@ class HelpOutput(object):
         yearly_avg = self.calc_area_yearly_avg()
         mask_years = (years >= year_from) & (years <= year_to)
 
-        for varname, label, color in zip(VARNAMES, LABELS, COLORS):
+        for varname in VARNAMES:
             masked_data = yearly_avg[varname].loc[mask_years]
             masked_years = masked_data.index.values.astype('int')
 
             ax.plot(masked_years, masked_data, marker='o', mec='white',
-                    clip_on=False, lw=2, color=color, label=label)
+                    clip_on=False, lw=2, color=COLORS[varname],
+                    label=LABELS[varname])
 
             slope, intercept, r_val, p_val, std_err = linregress(
                 masked_years, masked_data.values)
 
             ax.plot(masked_years, masked_years * slope + intercept,
                     marker=None, mec='white', clip_on=False, lw=1,
-                    dashes=[5, 3], color=color)
+                    dashes=[5, 3], color=COLORS[varname])
 
         ax.tick_params(axis='both', direction='out', labelsize=12)
         ax.set_ylabel('Composantes annuelles\ndu bilan hydrologique (mm/an)',

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -282,7 +282,7 @@ class HelpOutput(object):
         Plot the average yearly values of the water budget in mm/year
         for the whole study area.
         """
-        fig, ax = self._create_figure(fsize=(8, 6.5))
+        fig, ax = self._create_figure(fsize=(8.5, 5))
 
         text_offset = transforms.ScaledTranslation(
             0, 3/72, fig.dpi_scale_trans)
@@ -321,18 +321,14 @@ class HelpOutput(object):
         ax.set_xticklabels([])
 
         ax.legend(
-            numpoints=1, fontsize=12, borderaxespad=0, loc='upper right',
-            borderpad=0.5, bbox_to_anchor=(1, 1), ncol=1, frameon=False)
+            numpoints=1, fontsize=12, frameon=False, borderaxespad=0,
+            loc='lower left', borderpad=0.5, bbox_to_anchor=(0, 1, 1, 1),
+            ncol=2)
 
         fig.tight_layout()
 
         if figname is not None:
             fig.savefig(figname)
-
-        # Add a graph title.
-        # offset = transforms.ScaledTranslation(0/72, 12/72, fig.dpi_scale_trans)
-        # ax.text(0.5, 1, figname_sufix, fontsize=16, ha='center', va='bottom',
-                # transform=ax.transAxes+offset)
 
     def plot_area_yearly_series(self, figname=None):
         """

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -255,20 +255,19 @@ class HelpOutput(object):
 
         fig, ax = self._create_figure(fsize=(9, 6.5))
 
+        mask_years = (
+            (self.data['years'] >= year_from) &
+            (self.data['years'] <= year_to))
         months = list(range(1, 13))
         for varname in VARNAMES[:-1]:
             vardataf = avg_monthly[varname]
-            yearmask = (
-                (vardataf.index >= year_from) &
-                (vardataf.index <= year_to))
-            ax.plot(months, vardataf.loc[yearmask, :].mean(axis=0),
+            ax.plot(months, vardataf.loc[mask_years, :].mean(axis=0),
                     marker='o', ms=5, mec='white', clip_on=False, lw=2,
                     label=LABELS[varname], color=COLORS[varname])
 
         ax.set_ylabel(
             'Composantes mensuelles moyennes\ndu bilan hydrologique (mm/mois)',
             fontsize=16, labelpad=10)
-        ax.set_xlabel('Mois', fontsize=16, labelpad=10)
         ax.axis(ymin=-5)
         ax.grid(axis='y', color=[0.35, 0.35, 0.35], ls='-', lw=0.5)
         ax.set_xticks(months)
@@ -282,8 +281,19 @@ class HelpOutput(object):
             numpoints=1, fontsize=12, frameon=False, borderaxespad=0,
             loc='lower left', borderpad=0.5, bbox_to_anchor=(0, 1), ncol=2)
 
+        # Setup xlabel.
+        masked_years = self.data['years'][mask_years]
+        year_min = masked_years.min()
+        year_max = masked_years.max()
+        if year_min == year_max:
+            text = f"{year_min:0.0f}"
+        else:
+            text = f"{year_min:0.0f} - {year_max:0.0f}"
+        ax.set_xlabel(text, fontsize=16, labelpad=10)
+
         fig.tight_layout()
 
+        # Save figure to file.
         if figname is not None:
             fig.savefig(figname)
 
@@ -320,16 +330,17 @@ class HelpOutput(object):
             0, 3/72, fig.dpi_scale_trans)
 
         area_yearly_avg = self.calc_area_yearly_avg()
+        mask_years = (
+            (self.data['years'] >= year_from) &
+            (self.data['years'] <= year_to))
+
         x = 0
         text_handles = []
         for varname in VARNAMES[:-1]:
             x += 1
 
             vardataf = area_yearly_avg[varname]
-            yearmask = (
-                (vardataf.index >= year_from) &
-                (vardataf.index <= year_to))
-            var_avg_yearly = vardataf.loc[yearmask].mean()
+            var_avg_yearly = vardataf.loc[mask_years].mean()
 
             ax.bar(x, var_avg_yearly, 0.85, align='center',
                    label=LABELS[varname], color=COLORS[varname])
@@ -357,6 +368,16 @@ class HelpOutput(object):
             'Composantes annuelles moyennes\ndu bilan hydrologique (mm/an)',
             fontsize=16, labelpad=10)
         ax.set_xticklabels([])
+
+        # Setup xlabel.
+        masked_years = self.data['years'][mask_years]
+        year_min = masked_years.min()
+        year_max = masked_years.max()
+        if year_min == year_max:
+            text = f"{year_min:0.0f}"
+        else:
+            text = f"{year_min:0.0f} - {year_max:0.0f}"
+        ax.set_xlabel(text, fontsize=16, labelpad=10)
 
         ax.legend(
             numpoints=1, fontsize=12, frameon=False, borderaxespad=0,

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -250,7 +250,11 @@ class HelpOutput(object):
 
         months = list(range(1, 13))
         for varname, label in zip(VARNAMES, LABELS):
-            ax.plot(months, np.mean(avg_monthly[varname], axis=0),
+            vardataf = avg_monthly[varname]
+            yearmask = (
+                (vardataf.index >= year_from) &
+                (vardataf.index <= year_to))
+            ax.plot(months, vardataf.loc[yearmask, :].mean(axis=0),
                     marker='o', mec='white', clip_on=False, lw=2,
                     label=label)
 

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -301,8 +301,17 @@ class HelpOutput(object):
                         transform=ax.transData + text_offset))
         fig.canvas.draw()
 
+        # Setup axis limits.
+        ymax = 0
+        for handle in text_handles:
+            bbox = handle.get_window_extent(fig.canvas.get_renderer())
+            bbox = bbox.transformed(ax.transData.inverted())
+            ymax = max(ymax, bbox.y1)
+        ymax = np.ceil(ymax * 1.025)
+        print(ymax)
+        
+        ax.axis(ymin=0, ymax=ymax, xmin=0.25, xmax=6.75)
 
-        ax.axis(ymin=0, ymax=1200, xmin=0, xmax=7)
         ax.grid(axis='y', color=[0.35, 0.35, 0.35], ls='-', lw=0.5)
         ax.set_axisbelow(True)
 

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -195,7 +195,9 @@ class HelpOutput(object):
 
         return fig, ax
 
-    def plot_area_monthly_avg(self, figname=None):
+    def plot_area_monthly_avg(self, figname: str = None,
+                              year_from: int = -np.inf,
+                              year_to: int = np.inf) -> Figure:
         """
         Plot the monthly average values of the water budget in mm/month
         for the whole study area.
@@ -240,6 +242,8 @@ class HelpOutput(object):
 
         if figname is not None:
             fig.savefig(figname)
+
+        return fig
 
     def plot_area_yearly_avg(self, figname=None):
         """

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -251,14 +251,14 @@ class HelpOutput(object):
         months = list(range(1, 13))
         for varname, label in zip(VARNAMES, LABELS):
             ax.plot(months, np.mean(avg_monthly[varname], axis=0),
-                    marker=None, mec='white', clip_on=False, lw=2,
+                    marker='o', mec='white', clip_on=False, lw=2,
                     label=label)
 
         ax.set_ylabel('Moyennes mensuelles (mm/mois)',
                       fontsize=16, labelpad=10)
         ax.set_xlabel('Mois', fontsize=16, labelpad=10)
         ax.axis(ymin=-5)
-        ax.grid(axis='both', color=[0.35, 0.35, 0.35], ls='-', lw=0.5)
+        ax.grid(axis='y', color=[0.35, 0.35, 0.35], ls='-', lw=0.5)
         ax.set_xticks(months)
 
         # http://bdl.oqlf.gouv.qc.ca/bdl/gabarit_bdl.asp?id=3619

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -281,56 +281,32 @@ class HelpOutput(object):
         Plot the average yearly values of the water budget in mm/year
         for the whole study area.
         """
-        fig, ax = self._create_figure(
-            fsize=(8, 6.5), margins=(1.5, 0.5, 0.25, 0.25))
+        fig, ax = self._create_figure(fsize=(8, 6.5))
 
         area_yearly_avg = self.calc_area_yearly_avg()
-        avg_yearly_precip = np.mean(area_yearly_avg['precip'])
-        avg_yearly_rechg = np.mean(area_yearly_avg['rechg'])
-        avg_yearly_runoff = np.mean(area_yearly_avg['runoff'])
-        avg_yearly_evapo = np.mean(area_yearly_avg['evapo'])
-        avg_yearly_subrun1 = np.mean(area_yearly_avg['subrun1'])
-        avg_yearly_subrun2 = np.mean(area_yearly_avg['subrun2'])
-
-        l1 = ax.bar(1, avg_yearly_precip, 0.85, align='center')
-        l2 = ax.bar(2, avg_yearly_rechg, 0.85, align='center')
-        l3 = ax.bar(3, avg_yearly_runoff, 0.85, align='center')
-        l4 = ax.bar(4, avg_yearly_evapo, 0.85, align='center')
-        l5 = ax.bar(5, avg_yearly_subrun1, 0.85, align='center')
-        l6 = ax.bar(6, avg_yearly_subrun2, 0.85, align='center')
+        x = 0
+        for varname, label in zip(VARNAMES, LABELS):
+            x += 1
+            var_avg_yearly = area_yearly_avg[varname].mean()
+            ax.bar(x, var_avg_yearly, 0.85, align='center',
+                   label=label)
+            ax.text(x, var_avg_yearly + 10, "%d\nmm/an" % var_avg_yearly,
+                    ha='center', va='bottom')
 
         ax.axis(ymin=0, ymax=1200, xmin=0, xmax=7)
         ax.grid(axis='y', color=[0.35, 0.35, 0.35], ls='-', lw=0.5)
         ax.set_axisbelow(True)
 
-        ax.text(1, avg_yearly_precip + 10, "%d\nmm/an" % avg_yearly_precip,
-                ha='center', va='bottom')
-        ax.text(2, avg_yearly_rechg + 10, "%d\nmm/an" % avg_yearly_rechg,
-                ha='center', va='bottom')
-        ax.text(3, avg_yearly_runoff + 10, "%d\nmm/an" % avg_yearly_runoff,
-                ha='center', va='bottom')
-        ax.text(4, avg_yearly_evapo + 10, "%d\nmm/an" % avg_yearly_evapo,
-                ha='center', va='bottom')
-        ax.text(5, avg_yearly_subrun1 + 10, "%d\nmm/an" % avg_yearly_subrun1,
-                ha='center', va='bottom')
-        ax.text(6, avg_yearly_subrun2 + 10, "%d\nmm/an" % avg_yearly_subrun2,
-                ha='center', va='bottom')
-
         ax.tick_params(axis='y', direction='out', labelsize=12)
         ax.tick_params(axis='x', direction='out', length=0)
-        ax.set_ylabel('Composantes du bilan hydrologique\n(mm/an)',
-                      fontsize=16, labelpad=10)
+        ax.set_ylabel('Moyennes annuelles (mm/an)', fontsize=16, labelpad=10)
         ax.set_xticklabels([])
 
-        lines = [l1, l2, l3, l4, l5, l6]
-        labels = ["Précipitations totales", "Recharge au roc",
-                  "Ruissellement de surface", "Évapotranspiration",
-                  "Ruissellement hypodermique superficiel",
-                  "Ruissellement hypodermique profond"]
-        legend = ax.legend(lines, labels, numpoints=1, fontsize=12,
-                           borderaxespad=0, loc='upper right', borderpad=0.5,
-                           bbox_to_anchor=(1, 1), ncol=1)
-        legend.draw_frame(False)
+        ax.legend(
+            numpoints=1, fontsize=12, borderaxespad=0, loc='upper right',
+            borderpad=0.5, bbox_to_anchor=(1, 1), ncol=1, frameon=False)
+
+        fig.tight_layout()
 
         if figname is not None:
             fig.savefig(figname)

--- a/pyhelp/output.py
+++ b/pyhelp/output.py
@@ -93,11 +93,11 @@ class HelpOutput(object):
         Parameters
         ----------
         year_from : int, optional
-            Year from which the average annual values are calculated.
-            The default is -np.inf.
+            Minimum year of the period over which the average annual values
+            are calculated. The default is -np.inf.
         year_to : int, optional
-            Year to which the average annual values are calculated.
-            The default is np.inf.
+            Maximum year of the period over which the average annual values
+            are calculated. The default is np.inf.
         """
         print("Saving data to {}...".format(osp.basename(path_to_csv)))
         df = pd.DataFrame(index=self.data['cid'])
@@ -169,11 +169,11 @@ class HelpOutput(object):
         Parameters
         ----------
         year_from : int, optional
-            Year from which the average annual values are calculated.
-            The default is -np.inf.
+            Minimum year of the period over which the average annual values
+            are calculated. The default is -np.inf.
         year_to : int, optional
-            Year to which the average annual values are calculated.
-            The default is np.inf.
+            Maximum year of the period over which the average annual values
+            are calculated. The default is np.inf.
 
         Returns
         -------
@@ -233,11 +233,11 @@ class HelpOutput(object):
             Note that the format of the file is inferred from the extension of
             "figname".
         year_from : int, optional
-            Year from which the average monthly values are calculated.
-            The default is -np.inf.
+            Minimum year of the period over which the average monthly values
+            are calculated. The default is -np.inf.
         year_to : int, optional
-            Year to which the average monthly values are calculated.
-            The default is np.inf.
+            Maximum year of the period over which the average monthly values
+            are calculated. The default is np.inf.
 
         Returns
         -------
@@ -295,11 +295,11 @@ class HelpOutput(object):
             Note that the format of the file is inferred from the extension of
             "figname".
         year_from : int, optional
-            Year from which the average yearly values are calculated.
-            The default is -np.inf.
+            Minimum year of the period over which the average annual values
+            are calculated. The default is -np.inf.
         year_to : int, optional
-            Year to which the average yearly values are calculated.
-            The default is np.inf.
+            Maximum year of the period over which the average annual values
+            are calculated. The default is np.inf.
 
         Returns
         -------

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -81,22 +81,52 @@ def test_calc_help_cells(helpm, output_file):
         assert abs(np.sum(area_yrly_avg[key]) - expected_results[key]) < 1, key
 
 
-def test_plot_water_budget(output_dir, output_file):
+def test_plot_area_monthly_avg(output_dir, output_file):
     """
     Test that the water budget plots are created and saved as expected.
-
-    Regression test for Issue #29.
     """
     output = HelpOutput(output_file)
 
     figfilename = osp.join(output_dir, 'area_monthly_avg.pdf')
-    output.plot_area_monthly_avg(figfilename)
-    assert osp.exists(figfilename)
+    fig = output.plot_area_monthly_avg(
+        figfilename, year_from=2003, year_to=2009)
 
-    figfilename = osp.join(output_dir, 'area_yearly_series.pdf')
-    fig = output.plot_area_yearly_series(figfilename)
     assert fig is not None
     assert osp.exists(figfilename)
+
+    children = fig.axes[0].get_children()
+    assert (children[0].get_ydata().sum() - 1086.8448950125246) < 0.01  # precip
+    assert (children[1].get_ydata().sum() - 136.12068516893297) < 0.01  # rechg
+    assert (children[2].get_ydata().sum() - 226.9635476845988) < 0.01   # runoff
+    assert (children[3].get_ydata().sum() - 550.11140519815) < 0.01     # evapo
+    assert (children[4].get_ydata().sum() - 47.97935577404126) < 0.01   # subrun1
+    assert (children[5].get_ydata().sum() - 121.66539490800443) < 0.01  # subrun2
+
+
+def test_plot_area_yearly_series(output_dir, output_file):
+    """
+    Test that plotting the yearly values is working expected.
+    """
+    output = HelpOutput(output_file)
+
+    figfilename = osp.join(output_dir, 'area_yearly_series.pdf')
+    fig = output.plot_area_yearly_series(
+        figfilename, year_from=2003, year_to=2009)
+
+    assert fig is not None
+    assert osp.exists(figfilename)
+
+    expected_xdata = [2003, 2004, 2005, 2006, 2007, 2008, 2009]
+
+    children = fig.axes[0].get_children()
+    for i in range(12):
+        assert list(children[i].get_xdata()) == expected_xdata
+    assert (children[0].get_ydata().mean() - 1086.8448950125246) < 0.01   # precip
+    assert (children[2].get_ydata().mean() - 136.12068516893297) < 0.01   # rechg
+    assert (children[4].get_ydata().mean() - 226.9635476845988) < 0.01    # runoff
+    assert (children[6].get_ydata().mean() - 550.11140519815) < 0.01      # evapo
+    assert (children[8].get_ydata().mean() - 47.97935577404126) < 0.01    # subrun1
+    assert (children[10].get_ydata().mean() - 121.66539490800443) < 0.01  # subrun2
 
 
 def test_plot_area_yearly_avg(output_dir, output_file):
@@ -113,17 +143,17 @@ def test_plot_area_yearly_avg(output_dir, output_file):
     assert osp.exists(figfilename)
 
     children = fig.axes[0].get_children()
-    assert (children[0].get_height() - 1086.8448950125246) < 0.1   # precip
+    assert (children[0].get_height() - 1086.8448950125246) < 0.01   # precip
     assert children[1].get_text() == '1087\nmm/an'
-    assert (children[2].get_height() - 136.12068516893297) < 0.1   # rechg
+    assert (children[2].get_height() - 136.12068516893297) < 0.01   # rechg
     assert children[3].get_text() == '136\nmm/an'
-    assert (children[4].get_height() - 226.9635476845988) < 0.1    # runoff
+    assert (children[4].get_height() - 226.9635476845988) < 0.01    # runoff
     assert children[5].get_text() == '227\nmm/an'
-    assert (children[6].get_height() - 550.11140519815) < 0.1      # evapo
+    assert (children[6].get_height() - 550.11140519815) < 0.01      # evapo
     assert children[7].get_text() == '550\nmm/an'
-    assert (children[8].get_height() == 47.97935577404126) < 0.1   # subrun1
+    assert (children[8].get_height() - 47.97935577404126) < 0.01    # subrun1
     assert children[9].get_text() == '48\nmm/an'
-    assert (children[10].get_height() - 121.66539490800443) < 0.1  # subrun2
+    assert (children[10].get_height() - 121.66539490800443) < 0.01  # subrun2
     assert children[11].get_text() == '122\nmm/an'
 
 

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -22,7 +22,7 @@ from pandas.api.types import is_string_dtype
 # ---- Local library imports
 from pyhelp import __rootdir__
 from pyhelp.managers import HelpManager
-from pyhelp.output import HelpOutput
+from pyhelp.output import HelpOutput, VARNAMES
 
 EXAMPLE_FOLDER = osp.join(osp.dirname(__rootdir__), 'example')
 INPUT_FILES = {
@@ -165,9 +165,7 @@ def test_save_output_to_csv(output_dir, output_file):
     # Assert that the content of the csv is as expected.
     df = pd.read_csv(csvfilename, dtype={'cid': 'str'})
     df = df.set_index('cid', drop=True)
-    assert list(df.columns) == [
-        'lat_dd', 'lon_dd', 'precip', 'runoff', 'evapo', 'perco',
-        'subrun1', 'subrun2', 'rechg']
+    assert list(df.columns) == ['lat_dd', 'lon_dd'] + VARNAMES
     assert df.index.name == 'cid'
     assert len(df) == 98
 

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -93,13 +93,38 @@ def test_plot_water_budget(output_dir, output_file):
     output.plot_area_monthly_avg(figfilename)
     assert osp.exists(figfilename)
 
-    figfilename = osp.join(output_dir, 'area_yearly_avg.pdf')
-    output.plot_area_yearly_avg(figfilename)
+    figfilename = osp.join(output_dir, 'area_yearly_series.pdf')
+    fig = output.plot_area_yearly_series(figfilename)
+    assert fig is not None
     assert osp.exists(figfilename)
 
-    figfilename = osp.join(output_dir, 'area_yearly_series.pdf')
-    output.plot_area_yearly_series(figfilename)
+
+def test_plot_area_yearly_avg(output_dir, output_file):
+    """
+    Test that plotting the yearly averages is working expected.
+    """
+    output = HelpOutput(output_file)
+
+    figfilename = osp.join(output_dir, 'area_yearly_avg.pdf')
+    fig = output.plot_area_yearly_avg(
+        figfilename, year_from=2003, year_to=2009)
+
+    assert fig is not None
     assert osp.exists(figfilename)
+
+    children = fig.axes[0].get_children()
+    assert (children[0].get_height() - 1086.8448950125246) < 0.1   # precip
+    assert children[1].get_text() == '1087\nmm/an'
+    assert (children[2].get_height() - 136.12068516893297) < 0.1   # rechg
+    assert children[3].get_text() == '136\nmm/an'
+    assert (children[4].get_height() - 226.9635476845988) < 0.1    # runoff
+    assert children[5].get_text() == '227\nmm/an'
+    assert (children[6].get_height() - 550.11140519815) < 0.1      # evapo
+    assert children[7].get_text() == '550\nmm/an'
+    assert (children[8].get_height() == 47.97935577404126) < 0.1   # subrun1
+    assert children[9].get_text() == '48\nmm/an'
+    assert (children[10].get_height() - 121.66539490800443) < 0.1  # subrun2
+    assert children[11].get_text() == '122\nmm/an'
 
 
 def test_calc_cells_yearly_avg(output_file):
@@ -148,6 +173,9 @@ def test_calc_cells_yearly_avg(output_file):
         'runoff': 164.32582637467374,
         'subrun1': 56.33706154407843,
         'subrun2': 140.96849990912418}
+    for varname in list(expected_results.keys()):
+        result = np.sum(yearly_avg[varname]) / len(yearly_avg[varname])
+        assert abs(result - expected_results[varname]) < 1, varname
 
 
 def test_save_output_to_csv(output_dir, output_file):


### PR DESCRIPTION
Add the option to specify a `year_from` and `year_to` between which monthly and yearly values are calculated and plotted.

The methods affected by the changes made in this PR are:

```
output_help.plot_area_monthly_avg(year_from=2003, year_to=2007)
output_help.plot_area_yearly_avg(year_from=2003, year_to=2007)
output_help.plot_area_yearly_series(year_from=2004, year_to=2009)
```

Also, various improvements were made to the graphs produced by the above methods.

![Figure_1](https://user-images.githubusercontent.com/10170372/165368169-da98ac0d-3f6a-4418-9cf8-706e6f5b9230.png)

![Figure_2](https://user-images.githubusercontent.com/10170372/165368187-bbef10ab-8183-4c1e-820d-80ed30f6c8cd.png)

![Figure_3](https://user-images.githubusercontent.com/10170372/165368267-8091e8f9-da3c-476c-863e-080a88ef82b3.png)
