### PR TITLE
PR: Pin setuptools to the 58 series and liblief to the 0.10 series

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ skip_commits:
     - '**/*.jpg'
 
 image:
-  - Previous Visual Studio 2019
+  - Visual Studio 2019
 
 environment:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,7 +80,7 @@ test_script:
 after_test:
   - IF ["%APPVEYOR_PULL_REQUEST_NUMBER%"]==[""] (%PYTHON%/python.exe setup.py sdist bdist_wheel)
   - 7z a -tzip dist/example_pyhelp_%PYHELP_VERSION%.zip example/*.csv example/help_example.py example/CWEEDS/*
-  - conda-build recipe --no-test --output-folder dist --python %PYTHON_VERSION%
+  - IF ["%APPVEYOR_PULL_REQUEST_NUMBER%"]==[""] (conda-build recipe --no-test --output-folder dist --python %PYTHON_VERSION%)
 
 artifacts:
   - path: 'dist/*.whl'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ install:
   - conda config --set always_yes yes
   - conda update -q conda
   - conda config --set auto_update_conda no
-  - conda install pandas scipy h5py=3 matplotlib pip m2w64-toolchain conda-build setuptools=58
+  - conda install pandas scipy h5py=3 matplotlib pip m2w64-toolchain conda-build setuptools=58 liblief=0.10
   - python -m pip install codecov pytest pytest-cov
 
   # Check that we have still the expected version and architecture for Python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ install:
   - conda config --set always_yes yes
   - conda update -q conda
   - conda config --set auto_update_conda no
-  - conda install pandas scipy h5py=3 matplotlib pip m2w64-toolchain conda-build
+  - conda install pandas scipy h5py=3 matplotlib pip m2w64-toolchain conda-build=3.21.7
   - python -m pip install codecov pytest pytest-cov
 
   # Check that we have still the expected version and architecture for Python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ install:
   - conda config --set always_yes yes
   - conda update -q conda
   - conda config --set auto_update_conda no
-  - conda install pandas scipy h5py=3 matplotlib pip m2w64-toolchain conda-build
+  - conda install pandas scipy h5py=3 matplotlib pip m2w64-toolchain conda-build setuptools=58
   - python -m pip install codecov pytest pytest-cov
 
   # Check that we have still the expected version and architecture for Python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,7 +80,6 @@ test_script:
 after_test:
   - IF ["%APPVEYOR_PULL_REQUEST_NUMBER%"]==[""] (%PYTHON%/python.exe setup.py sdist bdist_wheel)
   - 7z a -tzip dist/example_pyhelp_%PYHELP_VERSION%.zip example/*.csv example/help_example.py example/CWEEDS/*
-  - IF ["%APPVEYOR_PULL_REQUEST_NUMBER%"]==[""] (conda-build recipe --no-test --output-folder dist --python %PYTHON_VERSION%)
 
 artifacts:
   - path: 'dist/*.whl'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ install:
   - conda config --set always_yes yes
   - conda update -q conda
   - conda config --set auto_update_conda no
-  - conda install pandas scipy h5py=3 matplotlib pip m2w64-toolchain conda-build=3.21.7 setuptools=58
+  - conda install pandas scipy h5py=3 matplotlib pip m2w64-toolchain conda-build
   - python -m pip install codecov pytest pytest-cov
 
   # Check that we have still the expected version and architecture for Python

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,6 +80,7 @@ test_script:
 after_test:
   - IF ["%APPVEYOR_PULL_REQUEST_NUMBER%"]==[""] (%PYTHON%/python.exe setup.py sdist bdist_wheel)
   - 7z a -tzip dist/example_pyhelp_%PYHELP_VERSION%.zip example/*.csv example/help_example.py example/CWEEDS/*
+  - conda-build recipe --no-test --output-folder dist --python %PYTHON_VERSION%
 
 artifacts:
   - path: 'dist/*.whl'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ skip_commits:
     - '**/*.jpg'
 
 image:
-  - Visual Studio 2019
+  - Previous Visual Studio 2019
 
 environment:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ install:
   - conda config --set always_yes yes
   - conda update -q conda
   - conda config --set auto_update_conda no
-  - conda install pandas scipy h5py=3 matplotlib pip m2w64-toolchain conda-build=3.21.7
+  - conda install pandas scipy h5py=3 matplotlib pip m2w64-toolchain conda-build=3.21.7 setuptools=58
   - python -m pip install codecov pytest pytest-cov
 
   # Check that we have still the expected version and architecture for Python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ requirements:
     - numpy
     - m2w64-toolchain
     - libpython
+    - setuptools=58
   run:
     - python
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ requirements:
     - m2w64-toolchain
     - libpython
     - setuptools=58
+    - liblief=0.10
   run:
     - python
     - numpy


### PR DESCRIPTION
With setuptools 61.2.0, conda package fails to build. We had to pin it to the 58 series.

This is probably related to this warning, but I don't have time to investigate further.
```
C:\Miniconda37-x64\lib\site-packages\setuptools\command\install.py:37: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
```

Also, this message is now appearing when packaging :
![image](https://user-images.githubusercontent.com/10170372/165589503-eec432bb-111e-44e8-99ce-e872beb60f1c.png)

PGO: Profile-guided optimizations
https://docs.microsoft.com/en-us/cpp/build/profile-guided-optimizations?view=msvc-170