### PR TITLE
PR: Rework input grid and weather data files declaration

### DIFF
--- a/example/help_example.py
+++ b/example/help_example.py
@@ -2,6 +2,8 @@
 """
 This example shows how to use PyHELP to calculate the monthly water balance
 for a section of the Rivière du Nord watershed in the Laurentians, Quebec, Can.
+
+Updated for PyHELP version 0.3.1
 """
 
 import os.path as osp
@@ -15,14 +17,24 @@ if __name__ == '__main__':
     #    https://docs.python.org/3.6/library/
     #    multiprocessing.html#programming-guidelines
 
-    # Define the directory where the weather and grid input files are saved.
-    workdir = osp.dirname(__file__)
+    # Define the working directory.
+    workdir = "D:/Projets/pyhelp/example/"
 
-    # Instantiate the HelpManager.
-    helpm = HelpManager(workdir)
+    # Instantiate the HelpManager and provide the paths to the grid and
+    # weather input data files so that they are loaded automatically.
+    helpm = HelpManager(
+        workdir,
+        path_to_grid=workdir + 'input_grid.csv',
+        path_to_precip=workdir + 'precip_input_data.csv',
+        path_to_airtemp=workdir + 'airtemp_input_data.csv',
+        path_to_solrad=workdir + 'solrad_input_data.csv')
 
-    # Note that you can access the weather input data through
-    # the 'precip_data', 'airtemp_data', and 'solrad_data'  attributes.
+    # Note that you can access the grid input data through
+    # the 'grid' attribute of the HelpManager.
+
+    # Note that you can access the weather input data through the
+    # 'precip_data', 'airtemp_data', and 'solrad_data' attributes
+    # of the HelpManager.
 
     # Generates the input files required by the HELP model
     # for each cell of the grid.

--- a/pyhelp/managers.py
+++ b/pyhelp/managers.py
@@ -152,23 +152,35 @@ class HelpManager(object):
             self.grid = load_grid_from_csv(path_to_grid)
             print('Grid data read successfully from input csv file.')
 
-    def load_weather_input_data(self):
+    def load_weather_input_data(self, path_to_precip: str,
+                                path_to_airtemp: str,
+                                path_to_solrad: str):
         """
         Load input weather data.
 
-        Load the daily precipitation, average air temperature, and
-        global solar radiation from the input weather data files. By default,
-        those files must be saved in the working directory and named,
-        respectively, :file:`precip_input_data.csv`,
-        :file:`airtemp_input_data.csv`, and :file:`solrad_input_data.csv`.
+        Parameters
+        ----------
+        path_to_precip : str
+            The path to the csv file that contains the input data for the
+            daily total precipitation.
+        path_to_airtemp : str
+            The path to the csv file that contains the input data for the
+            daily average air temperature
+        path_to_solrad : str
+            The path to the csv file that contains the input data for the
+            daily global solar radiation.
         """
-        print('Reading input weather data from csv...')
-        self.precip_data = load_weather_from_csv(
-            osp.join(self.workdir, INPUT_PRECIP_FNAME))
-        self.airtemp_data = load_weather_from_csv(
-            osp.join(self.workdir, INPUT_AIRTEMP_FNAME))
-        self.solrad_data = load_weather_from_csv(
-            osp.join(self.workdir, INPUT_SOLRAD_FNAME))
+        print(f'Reading input precip data from {path_to_precip}...')
+        self.precip_data = load_weather_from_csv(path_to_precip)
+        self.precip_filename = path_to_precip
+
+        print(f'Reading input airtemp data from {path_to_airtemp}...')
+        self.airtemp_data = load_weather_from_csv(path_to_airtemp)
+        self.airtemp_filename = path_to_airtemp
+
+        print(f'Reading input solrad data from {path_to_solrad}...')
+        self.solrad_data = load_weather_from_csv(path_to_solrad)
+        self.solrad_filename = path_to_solrad
 
         datasets = [self.precip_data, self.airtemp_data, self.solrad_data]
         datasets_name = {

--- a/pyhelp/managers.py
+++ b/pyhelp/managers.py
@@ -44,9 +44,29 @@ class HelpManager(object):
     The :class:`~pyhelp.HelpManager` is a class whose main purpose
     is to evaluate the component of the hydrologic water budget at the
     regional scale with the HELP model.
+
+    Parameters
+    ----------
+    workdir : str
+        The path to the working directory.
+    path_to_grid : str
+        The path to the csv file that contains the geomatic data, surface
+        conditions, and soil and design data for each cell of the grid
+        dividing the study area. The default is None.
+    path_to_precip : str
+        The path to the csv file that contains the input data for the
+        daily total precipitation.
+    path_to_airtemp : str
+        The path to the csv file that contains the input data for the
+        daily average air temperature
+    path_to_solrad : str
+        The path to the csv file that contains the input data for the
+        daily global solar radiation.
     """
 
-    def __init__(self, workdir):
+    def __init__(self, workdir: str, path_to_grid: str,
+                 path_to_precip: str, path_to_airtemp: str,
+                 path_to_solrad: str):
         super().__init__()
         self.grid = None
         self.precip_data = None

--- a/pyhelp/managers.py
+++ b/pyhelp/managers.py
@@ -132,22 +132,24 @@ class HelpManager(object):
                       separators=(",", ": "), ensure_ascii=False)
 
     # ---- Grid and Input
-    def load_input_grid(self):
+    def load_input_grid(self, path_to_grid: str):
         """
         Load input grid data.
 
-        Load the grid containing the geomatic data, surface conditions, and
-        soil and design data for each cell of the grid dividing the study area.
-        By default, the input grid data file must be saved in the working
-        directory and named :file:`input_grid.csv`.
+        Parameters
+        ----------
+        path_to_grid : str
+            The path to the csv file that contains the geomatic data, surface
+            conditions, and soil and design data for each cell of the grid
+            dividing the study area.
         """
-        print('Reading grid data from input csv file...')
-        grid_fname = osp.join(self.workdir, INPUT_GRID_FNAME)
-        if not osp.exists(grid_fname):
+        self.grid_filename = osp.abspath(path_to_grid)
+        print(f'Reading grid data from {path_to_grid}...')
+        if not osp.exists(path_to_grid):
             self.grid = None
             print("Grid input csv file does not exist.")
         else:
-            self.grid = load_grid_from_csv(grid_fname)
+            self.grid = load_grid_from_csv(path_to_grid)
             print('Grid data read successfully from input csv file.')
 
     def load_weather_input_data(self):

--- a/pyhelp/managers.py
+++ b/pyhelp/managers.py
@@ -33,10 +33,6 @@ from pyhelp.output import HelpOutput
 
 
 FNAME_CONN_TABLES = 'connect_table.json'
-INPUT_PRECIP_FNAME = 'precip_input_data.csv'
-INPUT_AIRTEMP_FNAME = 'airtemp_input_data.csv'
-INPUT_SOLRAD_FNAME = 'solrad_input_data.csv'
-INPUT_GRID_FNAME = 'input_grid.csv'
 
 
 class HelpManager(object):
@@ -73,8 +69,10 @@ class HelpManager(object):
         self.airtemp_data = None
         self.solrad_data = None
 
-        self._workdir = None
         self.set_workdir(workdir)
+        self.load_input_grid(path_to_grid)
+        self.load_weather_input_data(
+            path_to_precip, path_to_airtemp, path_to_solrad)
 
         self._load_connect_tables()
 
@@ -103,14 +101,10 @@ class HelpManager(object):
 
     def set_workdir(self, dirname):
         """Set the working directory of the manager."""
-        if self.workdir is not None and osp.samefile(self.workdir, dirname):
-            return
+        self._workdir = dirname
         if not osp.exists(dirname):
             os.makedirs(dirname)
         os.chdir(dirname)
-        self._workdir = dirname
-        self.load_input_grid()
-        self.load_weather_input_data()
 
     # ---- Connect tables
     @property

--- a/pyhelp/managers.py
+++ b/pyhelp/managers.py
@@ -585,9 +585,6 @@ def load_weather_from_csv(filename: str) -> pd.DataFrame:
     to the dates and the columns to latitudes and longitudes of each
     data series.
     """
-    if not osp.exists(filename):
-        return None
-
     with open(filename, 'r') as csvfile:
         reader = list(csv.reader(csvfile, delimiter=','))
 

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -11,13 +11,11 @@
 import os
 import os.path as osp
 
-
 # ---- Third party imports
 import numpy as np
 import pandas as pd
 import pytest
 from pandas.api.types import is_string_dtype
-
 
 # ---- Local library imports
 from pyhelp import __rootdir__
@@ -46,8 +44,13 @@ def output_file(output_dir):
 
 
 @pytest.fixture
-def helpm():
-    manager = HelpManager(EXAMPLE_FOLDER)
+def helpm(output_dir):
+    manager = HelpManager(
+        workdir=output_dir,
+        path_to_grid=INPUT_FILES['grid'],
+        path_to_precip=INPUT_FILES['precip'],
+        path_to_airtemp=INPUT_FILES['airtemp'],
+        path_to_solrad=INPUT_FILES['solrad'])
     return manager
 
 


### PR DESCRIPTION
From now on, the grid and weather data will not be loaded automatically from input files with hard coded filenames. 

It is now going to be required to provide explicitly the path of the grid and weather input data files when instantiating a new `HelpManager`. For example :

```python
from pyhelp.managers import HelpManager

helpm = HelpManager(
    workdir= 'C:/pyhelp/example/',
    path_to_grid='C:/pyhelp/example/my_input_grid_.csv',
    path_to_precip='C:/pyhelp/example/my_precip_input_data.csv',
    path_to_airtemp='C:/pyhelp/example/my_airtemp_input_data.csv',
    path_to_solrad='C:/pyhelp/example/my_solrad_input_data.csv')
```

The grid and weather data will be automatically loaded from the provided input data files when instantiating `HelpManager`.

By making the declaration of pyhelp input file paths explicit, we hope to reduce confusion about when data is loaded in the pyhelp workflow and reduce the risk of error by allowing the user to directly declare their input files without having to rename any file in their operating system.