### PR TITLE
PR: Build help input files implicitly when running help calculations

### DIFF
--- a/example/help_example.py
+++ b/example/help_example.py
@@ -36,14 +36,16 @@ if __name__ == '__main__':
     # 'precip_data', 'airtemp_data', and 'solrad_data' attributes
     # of the HelpManager.
 
+    # =========================================================================
+    # Run HELP simulation for all the cells in cellnames.
+    # =========================================================================
+
     # We want to run HELP only for the cells that are located within
     # a jauged subsection of the Rivière du Nord watershed.
 
     # The field "Bassin" was added to the grid input data to identify the
     # cells that are located within this jauged subsection of the watershed.
     cellnames = helpm.grid.index[helpm.grid['Bassin'] == 1]
-
-    # Run HELP simulation for all the cells in cellnames.
 
     # Note that the monthly output data will be automatically saved to
     # the HDF5 file define in filepath.
@@ -61,6 +63,10 @@ if __name__ == '__main__':
     output_help.plot_area_monthly_avg(fig_title="PyHELP Example")
     output_help.plot_area_yearly_avg(fig_title="PyHELP Example")
     output_help.plot_area_yearly_series(fig_title="PyHELP Example")
+
+    # =========================================================================
+    # Compare with river total and base streamflow
+    # =========================================================================
 
     # Calculate the yearly water budget for surface water cells.
     output_surf = helpm.calc_surf_water_cells(

--- a/example/help_example.py
+++ b/example/help_example.py
@@ -36,10 +36,6 @@ if __name__ == '__main__':
     # 'precip_data', 'airtemp_data', and 'solrad_data' attributes
     # of the HelpManager.
 
-    # Generates the input files required by the HELP model
-    # for each cell of the grid.
-    helpm.build_help_input_files(sf_edepth=0.15)
-
     # We want to run HELP only for the cells that are located within
     # a jauged subsection of the Rivière du Nord watershed.
 
@@ -52,9 +48,11 @@ if __name__ == '__main__':
     # Note that the monthly output data will be automatically saved to
     # the HDF5 file define in filepath.
     output_help = helpm.calc_help_cells(
-        path_to_hdf5=osp.join(workdir, 'help_example.out'),
+        path_to_hdf5=workdir + 'help_example.out',
         cellnames=cellnames,
-        tfsoil=-3)
+        tfsoil=-3,
+        sf_edepth=0.15,
+        sf_ulai=1)
 
     # Export and save annual averages of HELP output values to a csv file.
     output_help.save_to_csv(osp.join(workdir, 'help_example_yearly.csv'))

--- a/pyhelp/managers.py
+++ b/pyhelp/managers.py
@@ -231,13 +231,18 @@ class HelpManager(object):
         delete_folder_recursively(self.inputdir)
         print('done')
 
-    def build_help_input_files(self, sf_edepth: float = 1, sf_ulai: float = 1):
+    def build_help_input_files(self, cellnames: list = None,
+                               sf_edepth: float = 1, sf_ulai: float = 1):
         """
         Clear all cached HELP input data files and generate new ones from the
         weather and grid input data files.
 
         Parameters
         ----------
+        cellnames : list, optional
+            The list of cell ids for which D10 and D11 HELP input files
+            are to be generated. If None, D10 and D11 HELP input files are
+            generated for each cell of the grid with a "run" value of 1.
         sf_edepth : float, optional
             Global scale factor for the Evaporative Zone Depth (applied to
             the whole grid). The default is 1.
@@ -246,9 +251,10 @@ class HelpManager(object):
             the whole grid). The default is 1.
         """
         self.clear_cache()
-        self._generate_d10d11_input_files(sf_edepth=sf_edepth,
-                                          sf_ulai=sf_ulai)
-        self._generate_d4d7d13_input_files()
+        self._generate_d10d11_input_files(
+            cellnames, sf_edepth=sf_edepth, sf_ulai=sf_ulai)
+        self._generate_d4d7d13_input_files(
+            cellnames)
 
     def _generate_d10d11_input_files(self, cellnames: list = None,
                                      sf_edepth: float = 1, sf_ulai: float = 1):

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -66,9 +66,18 @@ def test_read_input_grid(helpm, output_file):
 def test_calc_help_cells(helpm, output_file):
     """Test that the HelpManager is able to run water budget calculation."""
     cellnames = helpm.cellnames[:100]
-    helpm.build_help_input_files()
+
     helpm.calc_help_cells(output_file, cellnames, tfsoil=-3)
     assert osp.exists(output_file)
+
+    inputdir = osp.join(helpm.inputdir, 'd10d11_input_files')
+    assert len(os.listdir(inputdir)) == 98 * 2
+    inputdir = osp.join(helpm.inputdir, 'D4_input_files')
+    assert len(os.listdir(inputdir)) == 2
+    inputdir = osp.join(helpm.inputdir, 'D7_input_files')
+    assert len(os.listdir(inputdir)) == 2
+    inputdir = osp.join(helpm.inputdir, 'D13_input_files')
+    assert len(os.listdir(inputdir)) == 1
 
     # Assert that the results are as expected.
     output = HelpOutput(output_file)


### PR DESCRIPTION
- This PR remove the need to call `HelpManager.build_help_input_files` before running HELP calculations with `HelpManager.calc_help_cells`. So in the help example, the line:

  `helpm.build_help_input_files(sf_edepth=0.15)`

  is not required anymore since the HELP input files are generated automatically when running :

  ```python
  output_help = helpm.HelpManager.calc_help_cells(
          path_to_hdf5=workdir + 'help_example.out',
          cellnames=cellnames,
          tfsoil=-3,
          sf_edepth=0.15,
          sf_ulai=1)
  ```

- We also added the possibility to build HELP input files for a list of cell ids instead of building the input files for the whole grid each time.

- Scaling factor are now passed directly as argument of HelpManager.calc_help_cells

- Finally, a new flag was added to `HelpManager.calc_help_cells`. This flag is called `build_help_input_files` and can be used to skip the building of the HELP input files as part of  `HelpManager.calc_help_cells`.