### PR TITLE
PR: Calculate and inject missing monthly climate normals into weather input files

### DIFF
--- a/pyhelp/HELP3O.FOR
+++ b/pyhelp/HELP3O.FOR
@@ -974,11 +974,11 @@ C
       END SUBROUTINE READCD
 
 
-C
-C      ************************* READIN *************************
-C
-C  SUBROUTINE READIN READS ET AND SOIL DESIGN DATA, AND WEATHER HEADERS
-C
+      !=================================================================
+      ! SUBROUTINE: READIN
+      !
+      ! Reads ET and soil design data, and weather headers.
+      !=================================================================
       SUBROUTINE READIN (fpath_precip, fpath_tasavg, fpath_solrad,
      &                   d11_input, d10_nlines, d10_input, IERR)
 
@@ -1105,8 +1105,8 @@ C
         END DO
       END IF
 
-      ! Convert evaporative zone depth and wind speed to SI units
-      ! if needed.
+      ! Convert evaporative zone depth and wind speed to
+      ! IP units if SI units are used.
       IF (IU11 /= 1) THEN
         EDEPTH = EDEPTH / 2.54
         WIND = WIND / 1.609

--- a/pyhelp/HELP3O.FOR
+++ b/pyhelp/HELP3O.FOR
@@ -1100,9 +1100,7 @@ C
       ! Convert temperature from Fahrenheit to Celsius if IP units
       ! are used.
       IF (IU7 == 1) THEN
-        DO I = 1, 12
-          TM(I) = (TM(I) - 32.0) / 1.8
-        END DO
+        TM = (TM - 32.0) / 1.8
       END IF
 
       ! Convert evaporative zone depth and wind speed to

--- a/pyhelp/managers.py
+++ b/pyhelp/managers.py
@@ -309,6 +309,7 @@ class HelpManager(object):
                 dist = calc_dist_from_coord(grid_lat[i], grid_lon[i],
                                             data_lat, data_lon)
                 argmin = int(np.argmin(dist))
+                col = data.columns[argmin]
 
                 lat = data_lat[argmin]
                 lon = data_lon[argmin]
@@ -317,16 +318,13 @@ class HelpManager(object):
                 if not osp.exists(help_input_fname):
                     city = '{} at {:3.1f} ; {:3.1f}'.format(var, lat, lon)
                     if var in ('precip', 'airtemp'):
-                        to_help_func(help_input_fname,
-                                     data.index.year.values,
-                                     data.values[:, argmin],
-                                     city)
+                        to_help_func(
+                            help_input_fname, data[col], city
+                            )
                     elif var == 'solrad':
-                        to_help_func(help_input_fname,
-                                     data.index.year.values,
-                                     data.values[:, argmin],
-                                     city,
-                                     lat)
+                        to_help_func(
+                            help_input_fname, data[col], city, lat
+                            )
 
                 file_conn_tbl[cellname] = help_input_fname
                 index_conn_tbl[cellname] = argmin

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -294,13 +294,13 @@ def test_save_output_to_csv(output_dir, output_file):
     assert df.iloc[0]['lon_dd'] == output.data['lon_dd'][0]
 
     expected_results = {
-        'precip': 1055.86,
-        'perco': 251.59,
-        'evapo': 548.58,
-        'rechg': 130.19,
-        'runoff': 212.26,
-        'subrun1': 46.27,
-        'subrun2': 113.02}
+        'precip': 1055.859737334313,
+        'perco': 267.6719784568864,
+        'evapo': 527.1941984146556,
+        'rechg': 137.92593783036364,
+        'runoff': 213.45404069293568,
+        'subrun1': 50.6600028195145,
+        'subrun2': 121.90106029782127}
     for key in list(expected_results.keys()):
         result = df[key].sum() / len(df)
         expected_result = expected_results[key]
@@ -308,4 +308,4 @@ def test_save_output_to_csv(output_dir, output_file):
 
 
 if __name__ == '__main__':
-    pytest.main(['-x', __file__, '-v', '-rw'])
+    pytest.main(['-x', __file__, '-vv', '-rw'])

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -103,12 +103,12 @@ def test_calc_help_cells(
     output = HelpOutput(output_file)
     area_yrly_avg = output.calc_area_yearly_avg()
     expected_results = {'precip': 11614.46,
-                        'perco': 2767.51,
-                        'evapo': 6034.42,
-                        'rechg': 1432.13,
-                        'runoff': 2334.89,
-                        'subrun1': 509.02,
-                        'subrun2': 1243.24}
+                        'perco': 2944.3917630257497,
+                        'evapo': 5799.136182561213,
+                        'rechg': 1517.1853161339995,
+                        'runoff': 2347.9944476222922,
+                        'subrun1': 557.2600310146595,
+                        'subrun2': 1340.911663276034}
     for name, value in expected_results.items():
         result = np.sum(area_yrly_avg[name])
         assert abs(result - value) < 1, f'{name}: {result} vs {value}'

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -114,6 +114,88 @@ def test_calc_help_cells(
         assert abs(result - value) < 1, f'{name}: {result} vs {value}'
 
 
+def test_monthly_normals_in_weather_headers(helpm, output_file):
+    """
+    Test that monthly climate normals are correctly calculated and injected
+    into the 4th line of the D4 and D7 input files headers.
+
+    See cgq-qgc/pyhelp#127
+    """
+    # Generate the input files for the first cell
+    cellnames = helpm.cellnames[:1]
+    cellname = cellnames[0]
+
+    # -------------------------------------------------------------------------
+    # Test Precipitation (D4)
+    # -------------------------------------------------------------------------
+    d4_file = helpm.connect_tables['D4'][cellname]
+    d4_col_idx = helpm.connect_tables['precip'][cellname]
+
+    # Calculate the expected monthly normals directly from the pandas Series
+    precip = helpm.precip_data.iloc[:, d4_col_idx]
+    expected_d4_total = precip.resample("ME").sum()
+
+    expected_d4_total = precip.resample("ME").sum()
+    expected_d4_normals = (
+        expected_d4_total.groupby(expected_d4_total.index.month)
+        .mean()
+        .sort_index()
+        .values
+        .round(2)
+        )
+
+    with open(d4_file, 'r') as f:
+        d4_lines = f.readlines()
+
+    assert len(d4_lines) == (37 * 11) + 4
+
+    # The 4th line (index 3) should contain the 12 normals
+    d4_normals_line = d4_lines[3].rstrip('\n')
+
+    # Format F6.2 for 12 values means the line must be exactly
+    # 72 characters long
+    assert len(d4_normals_line) == 72
+
+    # Parse the strings back into floats
+    d4_parsed_normals = [
+        float(d4_normals_line[i:i+6]) for i in range(0, 72, 6)]
+    assert len(d4_parsed_normals) == 12
+
+    # Assert they match our expected values.
+    assert np.max(np.abs(d4_parsed_normals - expected_d4_normals)) < 0.001
+
+    # -------------------------------------------------------------------------
+    # Test Air Temperature (D7)
+    # -------------------------------------------------------------------------
+    d7_file = helpm.connect_tables['D7'][cellname]
+    d7_col_idx = helpm.connect_tables['airtemp'][cellname]
+
+    # Calculate the expected monthly normals directly from the pandas Series
+    airtemp = helpm.airtemp_data.iloc[:, d7_col_idx]
+    expected_d7_normals = (
+        airtemp.groupby(airtemp.index.month)
+        .mean()
+        .round(2)
+        .values
+        )
+
+    with open(d7_file, 'r') as f:
+        d7_lines = f.readlines()
+
+    assert len(d4_lines) == (37 * 11) + 4
+
+    d7_normals_line = d7_lines[3].rstrip('\n')
+    assert len(d7_normals_line) == 72
+
+    d7_parsed_normals = [
+        float(d7_normals_line[i:i+6]) for i in range(0, 72, 6)]
+    assert len(d7_parsed_normals) == 12
+
+    # Assert they match our expected values.
+    max_abs_err = np.max(np.abs(d7_parsed_normals - expected_d7_normals))
+    assert max_abs_err < 0.001, max_abs_err
+
+
 @pytest.mark.parametrize('fig_title', [None, 'Exemple figure title'])
 def test_plot_area_monthly_avg(output_dir, output_file, fig_title):
     """

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -133,7 +133,6 @@ def test_monthly_normals_in_weather_headers(helpm, output_file):
 
     # Calculate the expected monthly normals directly from the pandas Series
     precip = helpm.precip_data.iloc[:, d4_col_idx]
-    expected_d4_total = precip.resample("ME").sum()
 
     expected_d4_total = precip.resample("ME").sum()
     expected_d4_normals = (
@@ -182,7 +181,7 @@ def test_monthly_normals_in_weather_headers(helpm, output_file):
     with open(d7_file, 'r') as f:
         d7_lines = f.readlines()
 
-    assert len(d4_lines) == (37 * 11) + 4
+    assert len(d7_lines) == (37 * 11) + 4
 
     d7_normals_line = d7_lines[3].rstrip('\n')
     assert len(d7_normals_line) == 72

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -202,11 +202,11 @@ def test_plot_area_yearly_avg(output_dir, output_file, fig_title):
     children = fig.axes[0].get_children()
     expected_values = {
         'precip': 1086.8448950125246,
-        'rechg': 136.12068516893297,
-        'runoff': 226.9635476845988,
-        'evapo': 550.11140519815,
-        'subrun1': 47.97935577404126,
-        'subrun2': 121.66539490800443
+        'rechg': 144.59660495818275,
+        'runoff': 228.3554850746950,
+        'evapo': 526.3448146870115,
+        'subrun1': 52.79497962998723,
+        'subrun2': 131.34891390581527
         }
     for i, (name, value) in enumerate(expected_values.items()):
         height = children[i * 2].get_height()

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -231,12 +231,12 @@ def test_calc_cells_yearly_avg(output_file):
     yearly_avg = output.calc_cells_yearly_avg()
     expected_results = {
         'precip': 1055.8597373343132,
-        'perco': 251.5843470406275,
-        'evapo': 548.5954285729573,
-        'rechg': 130.18263914385366,
-        'runoff': 212.26214164981408,
-        'subrun1': 46.26946108344004,
-        'subrun2': 113.02721698440918}
+        'perco': 267.6719784568864,
+        'evapo': 527.1941984146556,
+        'rechg': 137.9259378303636,
+        'runoff': 213.45404069293568,
+        'subrun1': 50.6600028195145,
+        'subrun2': 121.90106029782129}
     for name, value in expected_results.items():
         result = np.mean(yearly_avg[name])
         assert abs(result - value) < 1, f'{name}: {result} vs {value}'
@@ -245,12 +245,12 @@ def test_calc_cells_yearly_avg(output_file):
     yearly_avg = output.calc_cells_yearly_avg(year_from=2003, year_to=2009)
     expected_results = {
         'precip': 1086.8448950125246,
-        'perco': 259.85654385728577,
-        'evapo': 550.11140519815,
-        'rechg': 136.12068516893297,
-        'runoff': 226.9635476845988,
-        'subrun1': 47.97935577404126,
-        'subrun2': 121.66539490800443}
+        'perco': 277.51113515960424,
+        'evapo': 526.3448146870114,
+        'rechg': 144.59660495818272,
+        'runoff': 228.3554850746951,
+        'subrun1': 52.79497962998723,
+        'subrun2': 131.34891390581527}
     for name, value in expected_results.items():
         result = np.mean(yearly_avg[name])
         assert abs(result - value) < 1, f'{name}: {result} vs {value}'
@@ -259,12 +259,12 @@ def test_calc_cells_yearly_avg(output_file):
     yearly_avg = output.calc_cells_yearly_avg(year_from=2003, year_to=2003)
     expected_results = {
         'precip': 1144.4142919267927,
-        'perco': 324.15252048559057,
-        'evapo': 492.4243657442988,
-        'rechg': 148.72946963740077,
-        'runoff': 164.32582637467374,
-        'subrun1': 56.33706154407843,
-        'subrun2': 140.96849990912418}
+        'perco': 336.00345882089516,
+        'evapo': 476.6673904049153,
+        'rechg': 156.26847950749251,
+        'runoff': 165.63211222926193,
+        'subrun1': 60.01800987070037,
+        'subrun2': 149.44863253173403}
     for name, value in expected_results.items():
         result = np.mean(yearly_avg[name])
         assert abs(result - value) < 1, f'{name}: {result} vs {value}'

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -169,11 +169,11 @@ def test_plot_area_yearly_series(output_dir, output_file, fig_title):
 
     expected_values = {
         'precip': 1086.8448950125246,
-        'rechg': 136.12068516893297,
-        'runoff': 226.9635476845988,
-        'evapo': 550.11140519815,
-        'subrun1': 47.97935577404126,
-        'subrun2': 121.66539490800443
+        'rechg': 144.59660495818275,
+        'runoff': 228.3554850746950,
+        'evapo': 526.3448146870115,
+        'subrun1': 52.79497962998723,
+        'subrun2': 131.34891390581527
         }
     for i, (name, value) in enumerate(expected_values.items()):
         result = children[i * 2].get_ydata().mean()

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -131,11 +131,11 @@ def test_plot_area_monthly_avg(output_dir, output_file, fig_title):
     children = fig.axes[0].get_children()
     expected_values = {
         'precip': 1086.8448950125246,
-        'rechg': 136.12068516893297,
-        'runoff': 226.9635476845988,
-        'evapo': 550.11140519815,
-        'subrun1': 47.97935577404126,
-        'subrun2': 121.66539490800443
+        'rechg': 144.59660495818275,
+        'runoff': 228.3554850746950,
+        'evapo': 526.3448146870115,
+        'subrun1': 52.79497962998723,
+        'subrun2': 131.34891390581527
         }
     for i, (name, value) in enumerate(expected_values.items()):
         result = children[i].get_ydata().sum()

--- a/pyhelp/weather_reader.py
+++ b/pyhelp/weather_reader.py
@@ -14,12 +14,13 @@ import calendar
 
 # ---- Third Party imports
 import numpy as np
+import pandas as pd
 
 # ---- Local imports
 from pyhelp.utils import save_content_to_csv
 
 
-def save_precip_to_HELP(filename, years, precip, city):
+def save_precip_to_HELP(filename: str, precip: pd.Series, city: str):
     """
     Formats and saves a daily precipitation time series in mm
     to the HELP format.
@@ -28,24 +29,44 @@ def save_precip_to_HELP(filename, years, precip, city):
     filename = filename if ext == '.D4' else filename + '.D4'
 
     fheader = format_weather_header_for_HELP(3, 2, city)
-    fdata = format_timeseries_for_HELP(years, precip, '{0:>10}', '{0:>5.1f}')
+
+    # Calculate and add monthly normals to header.
+    monthly_normals = precip.groupby(precip.index.month).mean().values
+    fheader.append([''.join([f'{x:>6.2f}' for x in monthly_normals])])
+
+    fdata = format_timeseries_for_HELP(
+        precip.index.year.values,
+        precip.values,
+        '{0:>10}', '{0:>5.1f}')
     save_content_to_csv(filename, fheader + fdata)
 
 
-def save_airtemp_to_HELP(filename, years, precip, city):
+def save_airtemp_to_HELP(filename: str, airtemp: pd.Series, city: str):
     """
-    Formats and saves a daily average air temperature time series in Celcius to
-    the HELP format.
+    Formats and saves a daily average air temperature time series in
+    Celcius to the HELP format.
     """
     root, ext = osp.splitext(filename)
     filename = filename if ext == '.D7' else filename + '.D7'
 
     fheader = format_weather_header_for_HELP(3, 2, city)
-    fdata = format_timeseries_for_HELP(years, precip, '{0:>5}', '{0:>6.1f}')
+
+    # Calculate and add monthly normals to header.
+    monthly_normals = airtemp.groupby(airtemp.index.month).mean().values
+    fheader.append([''.join([f'{x:>6.2f}' for x in monthly_normals])])
+
+    print(np.mean(monthly_normals))
+
+    fdata = format_timeseries_for_HELP(
+        airtemp.index.year.values,
+        airtemp.values,
+        '{0:>5}', '{0:>6.1f}')
     save_content_to_csv(filename, fheader + fdata)
 
 
-def save_solrad_to_HELP(filename, years, precip, city, lat):
+def save_solrad_to_HELP(
+        filename: str, solrad: pd.Series, city: str, lat: float
+        ):
     """
     Formats and saves a daily global solar radiation time series in MJ/m2/day
     to the HELP format.
@@ -54,7 +75,10 @@ def save_solrad_to_HELP(filename, years, precip, city, lat):
     filename = filename if ext == '.D13' else filename + '.D13'
 
     fheader = format_weather_header_for_HELP(3, 2, city, lat)
-    fdata = format_timeseries_for_HELP(years, precip, '{0:>5}', '{0:>6.2f}')
+    fdata = format_timeseries_for_HELP(
+        solrad.index.year.values,
+        solrad.values,
+        '{0:>5}', '{0:>6.2f}')
     save_content_to_csv(filename, fheader + fdata)
 
 
@@ -71,8 +95,6 @@ def format_weather_header_for_HELP(itype, iunits, city, lat=None):
     if lat is not None:
         # Append the latitude if the data are solar radiation.
         fheader.append(['{0:>6.2f}'.format(lat)])
-    else:
-        fheader.append([])
     return fheader
 
 

--- a/pyhelp/weather_reader.py
+++ b/pyhelp/weather_reader.py
@@ -99,19 +99,21 @@ def format_weather_header_for_HELP(itype, iunits, city, lat=None):
 def format_timeseries_for_HELP(years, data, year_format, data_format):
     fdata = []
     for year in np.unique(years):
-        # Selects the data and asserts that the data are complete for
-        # that year :
-
+        # Select the data and validate that the year is complete.
         indexes = np.where(years == year)[0]
         days_in_year = 366 if calendar.isleap(year) else 365
-        assert len(indexes) == days_in_year
+
+        if len(indexes) != days_in_year:
+            raise ValueError(
+                f"Incomplete yearly data for {year}: got "
+                f"{len(indexes)} values, expected {days_in_year}."
+                )
 
         # Adds zeros to complete de last row and reshape the data
-        # in a 37 x 10 grid:
-
+        # in a 37 x 10 grid for HELP.
         year_data = data[indexes]
-        year_data = np.hstack(
-            [year_data, np.zeros(10 - len(year_data) % 10)])
+        pad = 370 - len(year_data)
+        year_data = np.hstack([year_data, np.zeros(pad)])
         year_data = year_data.reshape(37, 10).tolist()
 
         # Save the data in a format compatible with HELP :

--- a/pyhelp/weather_reader.py
+++ b/pyhelp/weather_reader.py
@@ -31,7 +31,12 @@ def save_precip_to_HELP(filename: str, precip: pd.Series, city: str):
     fheader = format_weather_header_for_HELP(3, 2, city)
 
     # Calculate and add monthly normals to header.
-    monthly_normals = precip.groupby(precip.index.month).mean().values
+    monthly_totals = precip.resample("ME").sum()
+    monthly_normals = (
+        monthly_totals.groupby(monthly_totals.index.month)
+        .mean()
+        .sort_index()
+        .values)
     fheader.append([''.join([f'{x:>6.2f}' for x in monthly_normals])])
 
     fdata = format_timeseries_for_HELP(

--- a/pyhelp/weather_reader.py
+++ b/pyhelp/weather_reader.py
@@ -44,7 +44,7 @@ def save_precip_to_HELP(filename: str, precip: pd.Series, city: str):
 def save_airtemp_to_HELP(filename: str, airtemp: pd.Series, city: str):
     """
     Formats and saves a daily average air temperature time series in
-    Celcius to the HELP format.
+    Celsius to the HELP format.
     """
     root, ext = osp.splitext(filename)
     filename = filename if ext == '.D7' else filename + '.D7'

--- a/pyhelp/weather_reader.py
+++ b/pyhelp/weather_reader.py
@@ -55,8 +55,6 @@ def save_airtemp_to_HELP(filename: str, airtemp: pd.Series, city: str):
     monthly_normals = airtemp.groupby(airtemp.index.month).mean().values
     fheader.append([''.join([f'{x:>6.2f}' for x in monthly_normals])])
 
-    print(np.mean(monthly_normals))
-
     fdata = format_timeseries_for_HELP(
         airtemp.index.year.values,
         airtemp.values,


### PR DESCRIPTION
This PR fixes a fundamental and long-standing historical bug in `pyhelp` where the monthly normal precipitation and air temperature values were missing in the model's weather input files (`.D4` and `.D7`).

This issue was discovered while working on PR #123, which aims to improve how daily outputs are shared between Fortran and Pyhelp and to extend the number of returned variables. When analyzing the newly extracted daily surface and soil temperatures, it became apparent that the model’s baseline climate was behaving incorrectly.

Historically (even predating the creation of pyhelp), there was a misconception that the HELP Fortran engine calculated the site’s average monthly normals directly from the daily weather input data. Part of the reason is that the HELP documentation is not explicit about this requirement, and the Fortran code does not emit any warning or error when monthly normals are missing: it simply reads blanks and silently defaults them to 0.0 (see the `READIN` subroutine). Because the resulting impact on the final water balance is generally second-order, this bug was difficult to catch without a deep dive into the HELP codebase.

**How HELP actually uses Monthly Climate Normals:** In reality, the HELP model reads these static monthly normals during initialization (subroutine `INITIA`) to calculate the site's average yearly temperature (`AVT`) and seasonal temperature amplitude (`AMP`). When the normals are missing and default to 0, `AVT` and `AMP` are severely biased. `AVT` and `AMP` are also used in subroutine `SOLT` to compute the daily temperature of the soil within the evaporative zone, which is used in subroutine `CRPMOD` to simulate plant growth and decay.

**Impact on Vegetation and Evapotranspiration (ET):** Restoring `AVT` and `AMP` restores the model’s thermal vegetation mechanics, which HELP adapted from the **SWRRB** (Simulator for Water Resources in Rural Basins) and **EPIC** (Erosion-Productivity Impact Calculator) models:

  - **Heat Units & LAI:** The model now correctly computes Potential Heat Units (Growing Degree Days), improving the seasonal evolution of the Leaf Area Index (LAI) as the plant "greens up" and "dies back" (subroutine `CRPMOD`).

  - **Cold Stress:** The cold-temperature stress logic now reflects the actual site climatology, more appropriately shutting down transpiration during cold periods (subroutine `TSTR`).

**What this DOES NOT impact (Frozen Soil & Snowmelt):** HELP **does not** use the soil temperature profile (`TSEG`) or the monthly normals to determine if the ground is frozen. Frozen soil logic is handled entirely by an independent, empirical subroutine (`FRZCHK`) that is explicitly based on a modified **CREAMS** (Chemicals, Runoff, and Erosion from Agricultural Management Systems) approach. This routine relies exclusively on actual daily air temperatures (using a 30-day moving average) and the user-calibrated `TFSOIL` parameter.

Because of this decoupled logic, legacy results were largely protected from this bug. Winter runoff and frozen soil dynamics were still being calculated correctly based on daily weather.

**Note for Users:** After this update, pyhelp will automatically regenerate the `.D4` and `.D7` input files with the correct monthly normals when running a new simulation. Users should expect more realistic seasonal Evapotranspiration (ET) patterns. Because the frozen soil logic remains unchanged, previously calibrated `TFSOIL` values are still fundamentally valid, though slight recalibration of the overall water balance may be desired due to the improved ET and vegetation mechanics.

<img width="1036" height="829" alt="image" src="https://github.com/user-attachments/assets/01f61b17-3546-40fe-8df2-eb6da9e16872" />
