### PR TITLE
PR: Track actual ground surface temperature (`TSURF`) in HELP model

### DIFF
--- a/pyhelp/HELP3O.FOR
+++ b/pyhelp/HELP3O.FOR
@@ -3517,7 +3517,7 @@ C     GS = GS + TMPC/PHU
       ! SUBROUTINE: TSTR
       !
       ! Applies a temperature stress factor to crops if the daily
-      ! maximum temperature is more then 15 deg.C below the average
+      ! maximum temperature is more than 15 deg.C below the average
       ! annual temperature
       !=================================================================
       SUBROUTINE TSTR (TGX, TMPC)

--- a/pyhelp/HELP3O.FOR
+++ b/pyhelp/HELP3O.FOR
@@ -3513,12 +3513,13 @@ C     GS = GS + TMPC/PHU
       END SUBROUTINE SOLT
 
 
-C *************************** TSTR **************************
-C
-C      SUBROUTINE TSTR APPLIES A TEMPERATURE STRESS FACTOR TO CROPS
-C      IF THE DAILY MAXIMUM TEMPERATURE IS MORE THEN 15 DEG. C. BELOW
-C      THE AVERAGE ANNUAL TEMPERATURE
-C
+      !=================================================================
+      ! SUBROUTINE: TSTR
+      !
+      ! Applies a temperature stress factor to crops if the daily
+      ! maximum temperature is more then 15 deg.C below the average
+      ! annual temperature
+      !=================================================================
       SUBROUTINE TSTR (TGX, TMPC)
 
       COMMON /BLK21/ TB, TO, TS, AVT, AMP, ABD, PHU, GS, CV,
@@ -3533,9 +3534,9 @@ C
       END IF
       IF ((TMPC - 5.) .LE. (AVT - 15.)) TS = 0.
       RETURN
-      END
-C
-C
+      END SUBROUTINE TSTR
+
+
 C ************************* FRZCHK *******************************
 C
 C   SUBROUTINE FRZCHK DETERMINES THE OCCURENCE OF FROZEN SOIL

--- a/pyhelp/HELP3O.FOR
+++ b/pyhelp/HELP3O.FOR
@@ -2341,7 +2341,7 @@ C     COMPILER CORRECTIONS ABOVE
       COMMON /BLK19/ IPL, IHV, IPRE, IRUN, ITSOIL, IVEG
       COMMON /BLK20/ TSEG (7), Z (7), FCS (7), ST (7)
       COMMON /BLK21/ TB, TO, TS, AVT, AMP, ABD, PHU, GS, CV,
-     &  RSD, DM, WFT (12), DD, DLAI
+     &  RSD, DM, WFT (12), DD, DLAI, TSURF
 
       ! Setting base Temp, TB=0 degC; and optimal Temp, TO=20 degC.
       TB = 5.
@@ -3003,7 +3003,7 @@ C
       COMMON /BLK16/ LD(5), LP(6), LPQ(5), LCASE(5), IYR, IDA, MO,
      1  NSTEP(6), ND
       COMMON /BLK21/ TB, TO, TS, AVT, AMP, ABD, PHU, GS, CV,
-     1  RSD, DM, WFT (12), DD, DLAI
+     1  RSD, DM, WFT (12), DD, DLAI, TSURF
       COMMON /BLK27/ IFREZ, IDFS, IFCNT, KCNT, MXKCNT
       COMMON /BLK28/ WE, XNEGHS, XLIQW, TINDEX, STORGE, EXLAG(4), TWE
 C
@@ -3275,7 +3275,7 @@ C
       COMMON /BLK16/ LD(5), LP(6), LPQ(5), LCASE(5), IYR, IDA, MO,
      1  NSTEP(6), ND
       COMMON /BLK21/ TB, TO, TS, AVT, AMP, ABD, PHU, GS, CV,
-     1  RSD, DM, WFT (12), DD, DLAI
+     1  RSD, DM, WFT (12), DD, DLAI, TSURF
 C
       DATA SALB /0.23/
 C     DATA G /0.68/
@@ -3394,7 +3394,7 @@ C
       COMMON /BLK19/ IPL, IHV, IPRE, IRUN, ITSOIL, IVEG
       COMMON /BLK20/ TSEG (7), Z (7), FCS (7), ST (7)
       COMMON /BLK21/ TB, TO, TS, AVT, AMP, ABD, PHU, GS, CV,
-     1   RSD, DM, WFT (12), DD, DLAI
+     1   RSD, DM, WFT (12), DD, DLAI, TSURF
 C
       SUT = ST (7)*25.4/FCS (7)
       CDG = (.9*TSEG (7)/(TSEG (7) + EXP (9.93 -(.312*TSEG (7)))))+ .1
@@ -3468,7 +3468,7 @@ C     GS = GS + TMPC/PHU
      &  NSTEP(6), ND
       COMMON /BLK20/ TSEG (7), Z (7), FCS (7), ST (7)
       COMMON /BLK21/ TB, TO, TS, AVT, AMP, ABD, PHU, GS, CV,
-     &   RSD, DM, WFT (12), DD, DLAI
+     &   RSD, DM, WFT (12), DD, DLAI, TSURF
 
       ! DetermininG BCV.
       IF(CV.LT.0.0)CV=0.0
@@ -3496,10 +3496,10 @@ C     GS = GS + TMPC/PHU
          ST0 = WFT (MO)*5. + TMPC - 5.
       END IF
 
-      ! Calculate actual ground surface temperature (XX).
-      XX = BCV*TO + (1. - BCV)*ST0
+      ! Calculate actual ground surface temperature (TSURF).
+      TSURF = BCV*TO + (1. - BCV)*ST0
 
-      DT = XX - (AVT + AMP*COS (ALX))
+      DT = TSURF - (AVT + AMP*COS (ALX))
       DO K = 1, 7
          ZD = - Z (K)/DD
          IF(ABS(ZD) < 37.) THEN
@@ -3520,10 +3520,10 @@ C      IF THE DAILY MAXIMUM TEMPERATURE IS MORE THEN 15 DEG. C. BELOW
 C      THE AVERAGE ANNUAL TEMPERATURE
 C
       SUBROUTINE TSTR (TGX, TMPC)
-C
+
       COMMON /BLK21/ TB, TO, TS, AVT, AMP, ABD, PHU, GS, CV,
-     1   RSD, DM, WFT (12), DD, DLAI
-C
+     &   RSD, DM, WFT (12), DD, DLAI, TSURF
+
       IF (TMPC .GT. TO) TGX = 2.*TO - TB - TMPC
       RTO = ((TO - TMPC)/TGX)**2
       IF (RTO .GT. 200.) THEN


### PR DESCRIPTION
This PR refactors the Fortran engine to explicitly track globally the daily ground surface temperature, which was previously lost as a temporary local math variable.

In the `SOLT` (Soil Temperature) subroutine, the actual ground surface temperature, representing the physical boundary condition beneath any snow or vegetation cover, was calculated using a temporary local variable named `XX`.

We replaced the generic `XX` variable with a descriptive `TSURF` (Temperature of the surface) variable and added
`TSURF` to the `COMMON /BLK21/` memory block across all relevant subroutines.

This does not change the underlying physics or math of the model. It simply promotes the surface boundary temperature to a global variable, clearing the way for pyhelp to extract `TSURF` as part of the daily output arrays being developed in PR #123.