### PR TITLE
PR: Fix dummy Fortran file output

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -49,5 +49,5 @@ jobs:
       uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: true

--- a/pyhelp/HELP3O.FOR
+++ b/pyhelp/HELP3O.FOR
@@ -714,7 +714,7 @@ C
           CALL RECIRC (IMO)
 
           ! Call subroutine outday if daily output is desired.
-          IF (IOD == 1 .AND. IPRE >= 2) THEN
+          IF (IPRE >= 2 .AND. IOD == 1 .AND. IOF == 1) THEN
             CALL OUTDAY(SWE, ASTAR, SSTAR, NVAR)
           END IF
 

--- a/pyhelp/HELP3O.FOR
+++ b/pyhelp/HELP3O.FOR
@@ -718,7 +718,7 @@ C
             CALL OUTDAY(SWE, ASTAR, SSTAR, NVAR)
           END IF
 
-          IF (FILL_OUTDAY == 1) THEN
+          IF (IPRE >= 2 .AND. FILL_OUTDAY == 1) THEN
             CALL FILL_PY_OUTDAY(LMYR, SWE, NDVAR, PY_OUTDAY)
           END IF
 

--- a/pyhelp/tests/test_helpmanager.py
+++ b/pyhelp/tests/test_helpmanager.py
@@ -73,7 +73,8 @@ def test_read_input_grid(helpm, output_file):
     [(True, True), (False, False)]
     )
 def test_calc_help_cells(
-        helpm, output_file, write_help_input_files, write_help_output_files
+        helpm, output_file, write_help_input_files, write_help_output_files,
+        output_dir
         ):
     """Test that the HelpManager is able to run water budget calculation."""
     cellnames = helpm.cellnames[:100]
@@ -81,7 +82,8 @@ def test_calc_help_cells(
     helpm.calc_help_cells(
         output_file, cellnames, tfsoil=-3,
         write_help_input_files=write_help_input_files,
-        write_help_output_files=write_help_output_files
+        write_help_output_files=write_help_output_files,
+        help_output_kwargs={'IOD': 1, 'IOM': 1, 'IOA': 1},
         )
 
     assert osp.exists(output_file)
@@ -102,6 +104,9 @@ def test_calc_help_cells(
     assert osp.exists(outputdir) == write_help_output_files
     if write_help_output_files:
         assert len(os.listdir(outputdir)) == 98
+
+    # Make sure Fortran is not writing its input in a dummy file.
+    assert not osp.exists(osp.join(helpm.workdir, 'fort.8'))
 
     daily_outdir = osp.join(helpm.inputdir, 'Daily_output_files')
     assert not osp.exists(daily_outdir)


### PR DESCRIPTION
This PR addresses an issue where the Fortran engine was writing unwanted/dummy output files (like fort.8) during execution when `IOD` flag in `help_output_kwargs` was set to 1 and `write_help_output_files` was set to False.

Exemple:

```python
output_help = helpm.calc_help_cells(
        path_to_hdf5='D:/Desktop/help_example.out',
        cellnames=cellnames,
        write_help_output_files=False,
        help_output_kwargs={'IOD': 1, 'IOM': 1, 'IOA': 1},
        )
```