### PR TITLE
fix: build wheels on linux

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install build dependencies
-        run: python -m pip install build
+        run: pip install build
       - name: Build sdist
         run: python -m build --sdist
       - name: Upload sdist artifact
@@ -29,30 +29,24 @@ jobs:
           name: pyhelp-sdist
           path: dist/*.tar.gz
 
-  # Build the compiled Windows wheels for each Python version.
+  # Build the compiled wheels for each Python version and OS.
   build-wheels:
-    name: Build wheels for Python ${{ matrix.python-version }}
-    runs-on: windows-latest
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+      # cibuildwheel config lives in pyproject.toml [tool.cibuildwheel] so that
+      # a local `cibuildwheel --platform linux` run reproduces CI exactly.
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.19.0
+      - uses: actions/upload-artifact@v6
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build meson-python ninja numpy wheel
-      - name: Build wheel
-        run: python -m build --wheel
-      - name: Upload wheel artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: pyhelp-wheels-${{ matrix.python-version }}
-          path: dist/*.whl
+          name: pyhelp-wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
 
   # Publish to PyPI.
   pypi-publish:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -18,11 +18,12 @@ permissions:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
-      # If one Python version fails, don't cancel the others automatically.
+      # If one configuration fails, don't cancel the others automatically.
       fail-fast: false
       matrix:
+        os: [windows-latest, ubuntu-latest]
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
@@ -33,11 +34,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install gfortran (Linux)
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y gfortran
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
-        pip install meson-python ninja numpy wheel
         pip install --no-build-isolation -e .
 
     - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ parts/
 sdist/
 var/
 wheels/
+wheelhouse/
+buildir/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/README.md
+++ b/README.md
@@ -34,3 +34,39 @@ Pip Wheels are available for Python 3.11 to 3.13 on the Windows 64bits plateform
 To install PyHELP, along with all its dependencies, simply run the following command in a terminal:
 
 `python -m pip install pyhelp`
+
+### Building from source (Linux / macOS / development)
+
+On Linux and macOS, and when developing PyHELP, you need to build the compiled
+HELP3O extension from source. This requires a C and a **Fortran** compiler:
+
+- Debian/Ubuntu: `sudo apt install gfortran`
+- macOS: `brew install gcc`
+
+PyHELP supports Python 3.11 to 3.13 (Python 3.14 and newer are not yet
+supported), so make sure you work inside a virtual environment using one of
+these versions:
+
+```
+python3.12 -m venv .venv
+source .venv/bin/activate          # on Windows: .venv\Scripts\activate
+```
+
+Then install the build toolchain and PyHELP in editable mode:
+
+```
+pip install -r requirements-dev.txt
+pip install --no-build-isolation --editable .
+```
+
+`--no-build-isolation` makes meson-python install an import hook that
+**recompiles the HELP3O extension automatically** whenever the package is
+imported, so your changes to both the Python and the Fortran sources are picked
+up without reinstalling. To see the rebuild output, add
+`--config-settings=editable-verbose=true` to the editable install command.
+
+Run the test suite with:
+
+```
+python runtests.py
+```

--- a/meson.build
+++ b/meson.build
@@ -11,12 +11,12 @@ py = py_mod.find_installation(pure: false)
 py_dep = py.dependency()
 
 incdir_numpy = run_command(py,
-  ['-c', 'import numpy; print(numpy.get_include())'],
+['-c', 'import numpy; import pathlib; import os; print(pathlib.Path(numpy.get_include()).relative_to(os.getcwd()))'],
   check: true
   ).stdout().strip()
 
 incdir_f2py = run_command(py,
-    ['-c', 'import numpy.f2py; print(numpy.f2py.get_include())'],
+    ['-c', 'import numpy.f2py; import pathlib; import os; print(pathlib.Path(numpy.f2py.get_include()).relative_to(os.getcwd()))'],
     check : true
 ).stdout().strip()
 
@@ -24,7 +24,7 @@ inc_np = include_directories(incdir_numpy, incdir_f2py)
 
 # Generate the C wrapper using f2py
 help3o_c = custom_target('help3o_c',
-  input : 'pyhelp/HELP3O.FOR',
+  input : './pyhelp/HELP3O.FOR',
   output : ['HELP3Omodule.c', 'HELP3O-f2pywrappers.f'],
   command : [py, '-m', 'numpy.f2py', '@INPUT@', '-m', 'HELP3O',
              '--lower', '--build-dir', '@OUTDIR@',

--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,13 @@ help3o_c = custom_target('help3o_c',
              ]
 )
 
+# Windows uses static libs directly
+# For other OS this is done in the CI
+link_args = []
+if host_machine.system() == 'windows'
+  link_args = ['-static-libgfortran', '-static-libgcc']
+endif
+
 # Build extension using the generated C wrapper AND the original Fortran file
 py.extension_module(
   'HELP3O',
@@ -40,7 +47,7 @@ py.extension_module(
   dependencies: py_dep,
   install: true,
   subdir: 'pyhelp',
-  link_args: ['-static', '-static-libgfortran', '-static-libgcc', '-lquadmath']
+  link_args: link_args
 )
 
 # Install all Python files.

--- a/meson.build
+++ b/meson.build
@@ -11,12 +11,20 @@ py = py_mod.find_installation(pure: false)
 py_dep = py.dependency()
 
 incdir_numpy = run_command(py,
-['-c', 'import numpy; import pathlib; import os; print(pathlib.Path(numpy.get_include()).relative_to(os.getcwd()))'],
+['-c', '''import os, numpy
+try:
+    print(os.path.relpath(numpy.get_include()))
+except Exception:
+    print(numpy.get_include())'''],
   check: true
   ).stdout().strip()
 
 incdir_f2py = run_command(py,
-    ['-c', 'import numpy.f2py; import pathlib; import os; print(pathlib.Path(numpy.f2py.get_include()).relative_to(os.getcwd()))'],
+    ['-c', '''import os, numpy.f2py
+try:
+    print(os.path.relpath(numpy.f2py.get_include()))
+except Exception:
+    print(numpy.f2py.get_include())'''],
     check : true
 ).stdout().strip()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,20 @@ Homepage = "https://github.com/cgq-qgc/pyhelp"
 Repository = "https://github.com/cgq-qgc/pyhelp"
 
 [tool.meson-python.args]
+
+[tool.cibuildwheel]
+# PyPy has no working f2py; musllinux/Alpine needs a separate toolchain.
+skip = ["pp*", "*-musllinux*"]
+# f2py needs numpy + the meson toolchain present before each wheel build.
+before-build = "pip install meson-python meson ninja numpy"
+# Smoke-test the built wheel: import + exercise the compiled HELP3O extension.
+# --pyargs imports the *installed* pyhelp (with the compiled HELP3O) rather than
+# the source tree, which has no extension and would shadow it. Scoped to the
+# extension test; the full integration suite (which needs repo data files) runs
+# from source in python-test.yml.
+test-requires = "pytest"
+test-command = "python -m pytest --pyargs pyhelp.tests.test_help3o"
+
+[tool.cibuildwheel.linux]
+# manylinux_2_28 ships a recent-enough gfortran for f2py.
+manylinux-x86_64-image = "manylinux_2_28"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,11 @@ pytest
 pytest-cov
 sphinx
 wheel
+
+# Build toolchain for the compiled HELP3O Fortran extension.
+# Required in the active environment for a --no-build-isolation editable install
+# (meson-python recompiles the extension on import).
+meson-python
+meson
+ninja
+numpy


### PR DESCRIPTION
Salut / hi,

I've been struggling to build `pyhelp` for linux and in general installing/building from linux. We will soon be using it in workflows at the University of Neuchâtel and we'd like to steer away from windows. We'd love to have pre-compiled wheels for linux and be able to use it.

## How to reproduce
```
# on a fresh python venv in a linux machine (Ubuntu 26.04)
pip install git+https://github.com/cgq-qgc/pyhelp.git

 FAILED: [code=1] HELP3O.cpython-312-x86_64-linux-gnu.so
      cc  -o HELP3O.cpython-312-x86_64-linux-gnu.so HELP3O.cpython-312-x86_64-linux-gnu.so.p/meson-generated_.._HELP3Omodule.c.o HELP3O.cpython-312-x86_64-linux-gnu.so.p/meson-generated_.._HELP3O-f2pywrappers.f.o
      HELP3O.cpython-312-x86_64-linux-gnu.so.p/pyhelp_HELP3O.FOR.o HELP3O.cpython-312-x86_64-linux-gnu.so.p/5e5f13c441e6a48ed3988f8b7812ddf0995fc329_site-packages_numpy_f2py_src_fortranobject.c.o
      -L/usr/lib/gcc/x86_64-linux-gnu/15 -L/usr/lib/x86_64-linux-gnu -L/usr/lib/gcc/x86_64-linux-gnu/15/../../../x86_64-linux-gnu -L/usr/lib -L/usr/lib/gcc/x86_64-linux-gnu/15/../../../../lib
      -L/lib/x86_64-linux-gnu -L/lib/../lib -L/usr/lib/../lib -L/usr/lib/gcc/x86_64-linux-gnu/15/../../.. -L/lib -Wl,--as-needed -Wl,--allow-shlib-undefined -Wl,-O1 -shared -fPIC -static -static-libgfortran
      -static-libgcc -Wl,--start-group -lquadmath -lgfortran -lm -Wl,--end-group
      /usr/bin/x86_64-linux-gnu-ld.bfd: /usr/lib/gcc/x86_64-linux-gnu/15/crtbeginT.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object
      /usr/bin/x86_64-linux-gnu-ld.bfd: failed to set dynamic section sizes: bad value
      collect2: error: ld returned 1 exit status
      ninja: build stopped: subcommand failed.
```
After investigating, it seems that the issue is the static links in the `meson.build` file. 

This PR therefore introduces the following changes:
- Do only static links in `meson.build` for windows, for linux this is done dynamically as gfortran is likely present for them. The CI stage takes care of bundling the dynamic libraries for linux in the ci.
- Change in the CI (now using `cibuildwheel`) to build wheels for linux, changes tests in the ci to account for other os
- Added a description on how to build for devs in `README.md`
- Added dev dependencies to build the package

## Tests
### Wheels
Obviously, I can't trigger ci builds from the main repo as I don't have the rights. However, I tested:
```bash
# this now works on linux and creates the appropriate wheels
uvx cibuildwheel --platform linux
```
### Import as non-editable package
From my fork the package can be compiled and installed without issues.
```bash
uv pip install "git+https://github.com/lesimppa/pyhelp.git@lesimppa/make-build-on-non-windows" && uv run python -c "import pyhelp.HELP3O as h3O; print(h3O.run_simulation)"
```
### Import as editable package
Note the `--no-build-isolation` which is necessary. All tests pass on my machine.
```bash
git clone https://github.com/lesimppa/pyhelp.git 
cd pyhelp
git checkout lesimppa/make-build-on-non-windows
uv venv --python=3.12
uv pip install -r requirements-dev.txt
uv pip install -e . --no-build-isolation 
uv run runtests.py
```

Would love to see this in action in the CI. What do you think ?